### PR TITLE
Much better support for building on OS X by auto detecting more stuff

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ EXTRA_mtr_SOURCES = curses.c \
                     gtk.c
 DEFAULT_INCLUDES= $(GLIB_CFLAGS) -I.
 mtr_DEPENDENCIES = $(GTK_OBJ) $(CURSES_OBJ)
-mtr_LDFLAGS = $(GTK_OBJ) $(CURSES_OBJ) $(GLIB_LIBS)
+mtr_LDFLAGS = $(GTK_OBJ) $(CURSES_OBJ) $(GLIB_LIBS) $(RESOLV_LIBS)
 
 CLEANFILES = version.h
 BUILT_SOURCES = version.h

--- a/asn.c
+++ b/asn.c
@@ -21,13 +21,19 @@
     Released under GPL, as above.
 */
 
-#include <config.h>
+#include "asn.h"
 
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
 
+#ifndef __APPLE__
+#define BIND_8_COMPAT
+#endif
 #include <arpa/nameser.h>
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 #include <netdb.h>
 #include <netinet/in.h>
 #include <resolv.h>
@@ -35,11 +41,10 @@
 #include <sys/socket.h>
 
 
-#include <glib.h>
-
-
 int  PrintAS = 0;
+#ifndef NO_GLIB
 GHashTable * ashash = NULL;
+#endif
 
 char *asn_lookup(const char *domain)
 {

--- a/asn.h
+++ b/asn.h
@@ -16,12 +16,16 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
+#include <config.h>
+#ifndef NO_GLIB
 #include <glib.h>
-
+#endif
 
 /*  Prototypes for asn.c  */
 
 extern int PrintAS;
+#ifndef NO_GLIB
 extern GHashTable * ashash;
+#endif
 char *asn_lookup(const char *domain);
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_CHECK_SIZEOF(unsigned int, 4)
 AC_CHECK_SIZEOF(unsigned long, 4)
 
 AC_CHECK_HEADERS(ncurses.h ncurses/curses.h curses.h cursesX.h sys/types.h fcntl.h)
-AC_CHECK_HEADERS(socket.h sys/socket.h sys/xti.h)
+AC_CHECK_HEADERS(socket.h sys/socket.h sys/xti.h arpa/nameser_compat.h)
 
 # Some doc I found somewhere. :-) -- REW
 # - Macro: AC_CHECK_FUNC (FUNCTION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]])
@@ -46,6 +46,11 @@ AC_ARG_WITH(gtk,
 [  --without-gtk           Do not try to use GTK+ at all],
 WANTS_GTK=$withval, WANTS_GTK=yes)
 
+dnl Added ability to cleanly disable glib      (22 Feb 2013, Kyle J. McKay)
+AC_ARG_WITH(glib,
+[  --without-glib          Do not try to use glib at all],
+WANTS_GLIB=$withval, WANTS_GLIB=yes)
+
 AC_ARG_ENABLE(ipv6,
 [  --disable-ipv6          Do not enable IPv6],
 WANTS_IPV6=$enableval, WANTS_IPV6=yes)
@@ -59,7 +64,11 @@ if test "x$WANTS_GTK" = "xyes"; then
 else
 	AC_DEFINE(NO_GTK)
 	GTK_OBJ=""
-	PKG_CHECK_MODULES([GLIB], [glib-2.0])
+	if test "x$WANTS_GLIB" = "xyes"; then
+		PKG_CHECK_MODULES([GLIB], [glib-2.0])
+	else
+		AC_DEFINE(NO_GLIB, 1, [Define if you don't have the glib libraries available.])
+	fi
 fi
 
 AC_CHECK_FUNC(socket, , 
@@ -75,23 +84,115 @@ AC_CHECK_FUNC(gethostbyname, ,
 AC_CHECK_FUNCS(seteuid)
 #  AC_CHECK_FUNC(setuid, , AC_MSG_ERROR (I Need either seteuid or setuid))
 
-AC_CHECK_FUNC(res_mkquery, , 
-  AC_CHECK_LIB(bind, res_mkquery, , 
-   AC_CHECK_LIB(resolv, res_mkquery, ,
-     AC_CHECK_LIB(resolv, __res_mkquery, , AC_MSG_ERROR(No resolver library found)))))
+#AC_CHECK_FUNC(res_mkquery, ,
+#  AC_CHECK_LIB(bind, res_mkquery, ,
+#   AC_CHECK_LIB(resolv, res_mkquery, ,
+#     AC_CHECK_LIB(resolv, __res_mkquery, , AC_MSG_ERROR(No resolver library found)))))
 # This next line would override the just detected-or-not -lresolv. 
 # This apparently hurts BSD. And it's bad practise. So it should go. 
 # However, it probably didn't get added for nothing..... Holler if
 # removing it hurts your OS.... -- REW
 #LIBS="$LIBS -lresolv"
 
+dnl Improved tests to select resolver library  (22 Feb 2013, Kyle J. McKay)
+# See if a library is needed for res_mkquery and if so put it in RESOLV_LIBS
+RESOLV_LIBS=
+AC_SUBST(RESOLV_LIBS)
+AC_DEFUN([LIBRESOLVTEST_SRC], [
+AC_LANG_PROGRAM([[
+#include <netinet/in.h>
+#include <resolv.h>
+]], [[
+int (*res_mkquery_func)(int,...) = (int (*)(int,...))res_mkquery;
+(void)(*res_mkquery_func)(0);
+]])])
+AC_MSG_CHECKING([whether library required for res_mkquery])
+RESOLV_LIB_NONE=
+AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
+	[AC_MSG_RESULT([no])
+	RESOLV_LIB_NONE=yes],
+	[AC_MSG_RESULT([yes])])
+if test "x$RESOLV_LIB_NONE" = "x"; then
+	AC_MSG_CHECKING([for res_mkquery in -lbind])
+	STASH_LIBS="$LIBS"
+	LIBS="$STASH_LIBS -lbind"
+	AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
+		[AC_MSG_RESULT([yes])
+		RESOLV_LIBS=-lbind],
+		[AC_MSG_RESULT([no])])
+	if test "x$RESOLV_LIBS" = "x"; then
+		AC_MSG_CHECKING([for res_mkquery in -lresolv])
+		LIBS="$STASH_LIBS -lresolv"
+		AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
+			[AC_MSG_RESULT([yes])
+			RESOLV_LIBS=-lresolv],
+			[AC_MSG_RESULT([no])
+                        AC_MSG_ERROR(No resolver library found)])
+	fi
+	LIBS="$STASH_LIBS"
+fi
+
 AC_CHECK_FUNC(herror, , AC_DEFINE(NO_HERROR, 1, [Define if you don't have the herror() function available.]))
 AC_CHECK_FUNC(strerror, , AC_DEFINE(NO_STRERROR, 1, [Define if you don't have the strerror() function available.]))
 
+USES_IPV6=
 AC_CHECK_FUNC(getaddrinfo,
 [if test "$WANTS_IPV6" = "yes"; then
 	AC_DEFINE([ENABLE_IPV6], [], [Define to enable IPv6])
+	USES_IPV6=yes
 fi])
+
+dnl Check to see whether or not __res_state_ext needs to be defined  (22 Feb 2013, Kyle J. McKay)
+AC_DEFUN([NEED_RES_STATE_EXT_TEST_SRC], [
+AC_LANG_PROGRAM([[
+#include <netinet/in.h>
+#include <resolv.h>
+#ifdef __GLIBC__
+#define RESEXTIN6(r,i) (*(r._u._ext.nsaddrs[i]))
+#else
+#define RESEXTIN6(r,i) (r._u._ext.ext->nsaddrs[i].sin6)
+#endif
+]], [[
+struct __res_state res;
+return RESEXTIN6(res,0).sin6_addr.s6_addr[0];
+]])])
+AC_DEFUN([DEFINE_RES_STATE_EXT_TEST_SRC], [
+AC_LANG_PROGRAM([[
+#include <netinet/in.h>
+#include <resolv.h>
+#ifdef __GLIBC__
+#define RESEXTIN6(r,i) (*(r._u._ext.nsaddrs[i]))
+#else
+#define RESEXTIN6(r,i) (r._u._ext.ext->nsaddrs[i].sin6)
+struct __res_state_ext {
+	union res_sockaddr_union nsaddrs[MAXNS];
+	struct sort_list {
+		int     af;
+		union {
+			struct in_addr  ina;
+			struct in6_addr in6a;
+		} addr, mask;
+	} sort_list[MAXRESOLVSORT];
+	char nsuffix[64];
+	char nsuffix2[64];
+};
+#endif
+]], [[
+struct __res_state res;
+return RESEXTIN6(res,0).sin6_addr.s6_addr[0];
+]])])
+if test "x$USES_IPV6" = "xyes"; then
+	AC_MSG_CHECKING([whether __res_state_ext needs to be defined])
+	AC_COMPILE_IFELSE([NEED_RES_STATE_EXT_TEST_SRC],
+		[AC_MSG_RESULT([no])],
+		[AC_MSG_RESULT([yes])
+		AC_MSG_CHECKING([whether provided __res_state_ext definition can be compiled])
+		AC_COMPILE_IFELSE([DEFINE_RES_STATE_EXT_TEST_SRC],
+			[AC_MSG_RESULT([yes])
+			AC_DEFINE(NEED_RES_STATE_EXT, 1, [Define if struct __res_state_ext needs to be defined.])],
+			[AC_MSG_RESULT([no])
+			AC_MSG_ERROR(Need definition for struct __res_state_ext but unable to define it.)])])
+fi
 
 AC_CHECK_DECLS(errno, , , [[
 #include <errno.h>

--- a/curses.c
+++ b/curses.c
@@ -65,7 +65,9 @@
 #include "dns.h"
 #include "asn.h"
 #include "version.h"
+#ifndef NO_GLIB
 #include <glib.h>
+#endif
 #endif
 
 #include <time.h>
@@ -315,6 +317,7 @@ void mtr_curses_hosts(int startstat)
     mpls = net_mpls(at);
 
     if( addrcmp( (void *) addr, (void *) &unspec_addr, af ) != 0 ) {
+#ifndef NO_GLIB
 #ifdef ENABLE_IPV6
       struct in6_addr addr6 = *addr;
 #else
@@ -364,6 +367,7 @@ void mtr_curses_hosts(int startstat)
 
               printw("[AS%s] ", chas);
       }
+#endif /* NO_GLIB */
       name = dns_lookup(addr);
       if (! net_up(at))
 	attron(A_BOLD);
@@ -656,7 +660,9 @@ void mtr_curses_redraw(void)
 
 void mtr_curses_open(void)
 {
+#ifndef NO_GLIB
   ashash = g_hash_table_new(g_str_hash, g_str_equal);
+#endif
   initscr();
   raw();
   noecho(); 

--- a/dns.c
+++ b/dns.c
@@ -32,8 +32,13 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#ifndef __APPLE__
 #define BIND_8_COMPAT
+#endif
 #include <arpa/nameser.h>
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 #include <netdb.h>
 #include <resolv.h>
 #include <unistd.h>
@@ -57,14 +62,6 @@
 #define NSCOUNT6 myres.nscount
 #define NSSOCKADDR6(i) (&(myres._u._ext.ext->nsaddrs[i].sin6))
 #endif
-#endif
-
-/* OSX  Needs this. I don't know how to enable this for them automatically. 
- * Should be easy with autoconf. Please submit a patch if you know 
- * autoconf.... -- REW
- */
-#if 0 
-#include "nameser8_compat.h"
 #endif
 
 

--- a/dns.h
+++ b/dns.h
@@ -16,8 +16,9 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
+#include <config.h>
 #include <netinet/in.h>
-
+#include <resolv.h>
 
 /*  Prototypes for dns.c  */
 
@@ -27,10 +28,8 @@ void dns_ack(void);
 #ifdef ENABLE_IPV6
 int dns_waitfd6(void);
 void dns_ack6(void);
-#ifdef BSD
-/* __res_state_ext is missing on many (most?) BSD systems
-   - this should probably be handled by autoconf */
-#ifndef __res_state_ext
+#ifdef NEED_RES_STATE_EXT
+/* __res_state_ext is missing on many (most?) BSD systems */
 struct __res_state_ext {
 	union res_sockaddr_union nsaddrs[MAXNS];
 	struct sort_list {
@@ -43,7 +42,6 @@ struct __res_state_ext {
 	char nsuffix[64];
 	char nsuffix2[64];
 };
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
These autoconfigure changes have been tested on Linux, OS X and FreeBSD and work properly on all three platforms (and so does the built mtr executable).
- Add support for new --without-glib configure option to disable
  all use of glib (also requires --without-gtk to be effective).
  This has the side effect of disabling the "mtr -z" functionality.
- Improve configure support for detecting which library to link
  with, if any, to get the resolver functions.
- Do not define BIND_8_COMPAT when compiling for Darwin/OS X.
- Autoconfigure whether or not a suitable struct __res_state_ext
  needs to be defined.
- If the arpa/nameser_compat.h header is available and usable,
  include it immediately after arpa/nameser.h.

note: this pull request also includes the curses.c change that's already in a separate pull request as the github pull request interface seems unable to exclude it.  sorry about that.
