### PR TITLE
bumped version number to v0.84 in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mtr], [0.83])
+AC_INIT([mtr], [0.84])
 AC_CONFIG_SRCDIR([mtr.c])
 AM_INIT_AUTOMAKE([foreign])
 


### PR DESCRIPTION
The version number in `configure.ac` was still set to `v0.83`.
This pull request replaces `v0.83` to `v0.84` in `configure.ac`.

```
$ sudo ./mtr -v
mtr 0.84+git:8b25faa3
```
