### PR TITLE
fix building on osx

### DIFF
--- a/asn.c
+++ b/asn.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
-#ifndef __APPLE__
+#ifdef __APPLE__
 #define BIND_8_COMPAT
 #endif
 #include <arpa/nameser.h>


### PR DESCRIPTION
On Linux, they use 'BIND_4_COMPAT' and #include <arpa/nameser_compat.h> in <arpa/nameser.h>
    On OSX, if 'BIND_8_COMPAT' is #defined, <arpa/nameser_compat.h> is #included in <arpa/nameser.h>
