### PR TITLE
Moves include of config.h more to the top

### DIFF
--- a/asn.c
+++ b/asn.c
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include "config.h"
+
 #ifdef __APPLE__
 #define BIND_8_COMPAT
 #endif
@@ -35,7 +37,6 @@
 #include <sys/socket.h>
 #include <search.h>
 
-#include "config.h"
 #include "mtr.h"
 #include "asn.h"
 


### PR DESCRIPTION
This moves the include of `config.h` more to the top because otherwise
`HAVE_ARPA_NAMESER_COMPAT_H` is not shown.

This fixes issues on OS X (10.9).
