### PR TITLE
Restore the name resolver query order to their relative position in

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,7 +25,7 @@
         Mike Simons <msimons@moria.simons-clan.com>
         Aaron Scarisbrick
         Craig Milo Rogers <Rogers@ISI.EDU>
-        Antonio Querubin <tony@aloha.net>
+        Antonio Querubin <tony@lavanauts.org>
         Russell Nelson <rn-mtr@crynwr.com>
         Davin Milun
         Josh Martin <jmartin@columbiaservices.net>


### PR DESCRIPTION
/etc/resolv.conf (the IPv6 resolver patch I submitted earlier broke this
normal, expected behaviour).  Ie. currently, IPv6 resolvers are always
queried before IPv4 resolvers regardless of their position in
resolv.conf.

Update my email address in AUTHORS.
