### PR TITLE
Fix a potential buffer overrun from an off-by-one error.

### DIFF
--- a/net.c
+++ b/net.c
@@ -1393,7 +1393,7 @@ void net_save_return(int at, int seq, int ms)
 {
   int idx;
   idx = seq - host[at].saved_seq_offset;
-  if (idx < 0 || idx > SAVED_PINGS) {
+  if (idx < 0 || idx >= SAVED_PINGS) {
     return;
   }
   host[at].saved[idx] = ms;


### PR DESCRIPTION
An internal static analyzer found this possible overrun, which was pretty easy to fix.
