### PR TITLE
Disable keyboard input in "split" mode

### DIFF
--- a/display.c
+++ b/display.c
@@ -58,7 +58,6 @@ extern int DisplayMode;
 #define split_open()
 #define split_close()
 #define split_redraw()
-#define split_keyaction() 0
 #else
 #include "split.h"
 #endif
@@ -167,9 +166,6 @@ int display_keyaction(void)
   switch(DisplayMode) {
   case DisplayCurses:
     return mtr_curses_keyaction();
-
-  case DisplaySplit:
-    return split_keyaction();
 
   case DisplayGTK:
     return gtk_keyaction();

--- a/mtr.c
+++ b/mtr.c
@@ -62,6 +62,7 @@
 int   DisplayMode;
 int   display_mode;
 int   Interactive = 1;
+int   UserInput = 1;
 int   PrintVersion = 0;
 int   PrintHelp = 0;
 int   MaxPing = 10;
@@ -494,6 +495,14 @@ void parse_arg (int argc, char **argv)
       DisplayMode == DisplayRaw ||
       DisplayMode == DisplayCSV)
     Interactive = 0;
+
+  if (DisplayMode == DisplayReport ||
+      DisplayMode == DisplayTXT ||
+      DisplayMode == DisplayXML ||
+      DisplayMode == DisplayRaw ||
+      DisplayMode == DisplayCSV ||
+      DisplayMode == DisplaySplit)
+    UserInput = 0;
 
   if (optind > argc - 1)
     return;

--- a/select.c
+++ b/select.c
@@ -36,6 +36,7 @@
 #include "display.h"
 
 extern int Interactive;
+extern int UserInput;
 extern int MaxPing;
 extern int ForceMaxPing;
 extern float WaitTime;
@@ -79,7 +80,7 @@ void select_loop(void) {
 
     maxfd = 0;
 
-    if(Interactive) {
+    if(UserInput) {
       FD_SET(0, &readfd);
       maxfd = 1;
     }

--- a/split.c
+++ b/split.c
@@ -151,37 +151,3 @@ void split_close(void)
   printf("split_close()\n");
 #endif
 }
-
-
-int split_keyaction(void) 
-{
-#ifdef NO_CURSES
-  fd_set readfds;
-  struct timeval tv;
-  char c;
-
-  FD_ZERO (&readfds);
-  FD_SET (0, &readfds);
-  tv.tv_sec = 0;
-  tv.tv_usec = 0;
-
-  if (select (1, &readfds, NULL, NULL, &tv) > 0) {
-    read (0, &c, 1);
-  } else 
-    return 0;
-#else
-  char c = getch();
-#endif
-
-#if DEBUG
-  printf("split_keyaction()\n");
-#endif
-  if(tolower(c) == 'q')
-    return ActionQuit;
-  if(c==3)
-    return ActionQuit;
-  if(tolower(c) == 'r')
-    return ActionReset;
-  
-  return 0;
-}


### PR DESCRIPTION
Keyboard input does not seem useful in split mode, as the output is
probably meant to be parsed by another program.  Users can press ^C anyway
if they want to interrupt mtr.

It was helplessly broken anyway: no key press was actually taken into
account (see bug #30 on Github), _except_ the "Enter" key, which would
cause an infinite loop by calling select() repeatedly.
