### PR TITLE
Fixed to handle case where only IPv6 nameservers are specified

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -57,7 +57,7 @@
 
 #ifdef ENABLE_IPV6
 #ifdef __GLIBC__
-#define NSCOUNT myres.nscount + myres._u._ext.nscount6
+#define NSCOUNT (myres.nscount + myres._u._ext.nscount6)
 #define NSCOUNT6 myres._u._ext.nscount6
 #define NSSOCKADDR6(i) (myres._u._ext.nsaddrs[i])
 #else


### PR DESCRIPTION
At present, mtr will abort when only IPv6 nameservers are specified in /etc/resolv.conf as reported in https://bugs.launchpad.net/ubuntu/+source/mtr/+bug/752583. This fixes that by including a count of all IPv6 nameservers.
