### PR TITLE
Corrected the "without gtk" reference to "./configure --without-gtk", be...

### DIFF
--- a/README
+++ b/README
@@ -34,9 +34,9 @@ INSTALLING
   Note that mtr must be suid-root because it requires access to raw IP 
   sockets.  See SECURITY for security information.
 
-  Older versions used to require a non-existant path to GTK for a
+  Older versions used to require a non-existent path to GTK for a
   correct build of a non-gtk version while GTK was installed. This is
-  no longer neccesary. ./configure --WITHOUT_GTK should now work. 
+  no longer necessary. ./configure --without-gtk should now work. 
   If it doesn't, try "make WITHOUT_X11=YES" as the make step. 
 
   On Solaris (and possibly other systems) the "gtk" library may be
@@ -47,7 +47,7 @@ INSTALLING
   you're out of luck when you use the sun LD. That's not quite true, as
   you can move the gtk libraries to /usr/lib instead of leaving them in
   /usr/local/lib.  (when the ld tells you that /usr/local/lib is untrusted
-  and /usr/lib is trusted, and you trust hte gtk libs enough to want them
+  and /usr/lib is trusted, and you trust the gtk libs enough to want them
   in a setuid program, then there is something to say for moving them
   to the "trusted" directory.)
 


### PR DESCRIPTION
...cause the previous version "--WITHOUT_GTK" caused an error.

The error message was:
    configure: error: unrecognized option: `--WITHOUT_GTK'
Also fixed a couple of README typos.
