### PR TITLE
Ignore the space field in XML report.

### DIFF
--- a/report.c
+++ b/report.c
@@ -294,7 +294,7 @@ void xml_close(void)
     printf("    <HUB COUNT=\"%d\" HOST=\"%s\">\n", at+1, name);
     for( i=0; i<MAXFLD; i++ ) {
       j = fld_index[fld_active[i]];
-      if (j < 0) continue;
+      if (j <= 0) continue;
 
       strcpy(name, "        <%s>");
       strcat(name, data_fields[j].format);


### PR DESCRIPTION
Space field doesn't make much sense in XML report anyway, and would make it ill-formed if used. Since it is used in the default fields spec ("LS NABWV"), it makes the default report ill-formed.

Also, for some reason it produces something I wouldn't really expect:

```
    <HUB COUNT="7" HOST="google-public-dns-a.google.com">
        <Loss>  0.0%</Loss>
        <Snt>    10</Snt>
        < > </(null)>
        <Last>  80.2</Last>
        <Avg>  80.3</Avg>
        <Best>  80.1</Best>
        <Wrst>  80.4</Wrst>
        <StDev>   0.0</StDev>
    </HUB>
```
I'm not sure why the closing tag contains NULL. Maybe my dirty hack is for the wrong problem, or there is another problem that I don't see yet.
This behaviour existed before my previous patch about the Loss% field.