### PR TITLE
SCTP support

### DIFF
--- a/curses.c
+++ b/curses.c
@@ -264,6 +264,7 @@ int mtr_curses_keyaction(void)
     switch ( mtrtype ) {
     case IPPROTO_ICMP:
     case IPPROTO_TCP:
+    case IPPROTO_SCTP:
       mtrtype = IPPROTO_UDP;
       break;
     case IPPROTO_UDP:
@@ -276,9 +277,22 @@ int mtr_curses_keyaction(void)
     switch ( mtrtype ) {
     case IPPROTO_ICMP:
     case IPPROTO_UDP:
+    case IPPROTO_SCTP:
       mtrtype = IPPROTO_TCP;
       break;
     case IPPROTO_TCP:
+      mtrtype = IPPROTO_ICMP;
+      break;
+    }
+  }
+  if (tolower(c) == 's') {
+    switch ( mtrtype ) {
+    case IPPROTO_ICMP:
+    case IPPROTO_UDP:
+    case IPPROTO_TCP:
+      mtrtype = IPPROTO_SCTP;
+      break;
+    case IPPROTO_SCTP:
       mtrtype = IPPROTO_ICMP;
       break;
     }

--- a/net.c
+++ b/net.c
@@ -1712,7 +1712,7 @@ void net_process_fds(fd_set *writefd)
   for (at = 0; at < MaxSequence; at++) {
     fd = sequence[at].socket;
     if (fd > 0 && FD_ISSET(fd, writefd)) {
-      r = write(fd, "G", 1);
+      r = send(fd, "G", 1, MSG_NOSIGNAL);
       /* if write was successful, or connection refused we have
        * (probably) reached the remote address. Anything else happens to the
        * connection, we write it off to avoid leaking sockets */

--- a/select.c
+++ b/select.c
@@ -107,7 +107,7 @@ void select_loop(void) {
     FD_SET(netfd, &readfd);
     if(netfd >= maxfd) maxfd = netfd + 1;
 
-    if (mtrtype == IPPROTO_TCP)
+    if (mtrtype == IPPROTO_TCP || mtrtype == IPPROTO_SCTP)
       net_add_fds(&writefd, &maxfd);
 
     do {
@@ -266,7 +266,7 @@ void select_loop(void) {
     }
 
     /* Check for activity on open sockets */
-    if (mtrtype == IPPROTO_TCP)
+    if (mtrtype == IPPROTO_TCP || mtrtype == IPPROTO_SCTP)
       net_process_fds(&writefd);
   }
   return;


### PR DESCRIPTION
I added codes about SCTP in *curses.c* and *select.c* this time, and got SIGPIPE when MTRing to a non-existent address (which causes a loop route between two routers).
I just modified *net.c*, to avoid the SIGPIPE, but I don't know if I'm doing the right thing, as I'm not familiar with the whole program.