### PR TITLE
Remove a warning message at compile time.

### DIFF
--- a/display.c
+++ b/display.c
@@ -38,7 +38,7 @@ extern int DisplayMode;
 #define mtr_curses_open()
 #define mtr_curses_close()
 #define mtr_curses_redraw()
-#define mtr_curses_keyaction()
+#define mtr_curses_keyaction() 0
 #define mtr_curses_clear()
 #else
 #include "mtr-curses.h"


### PR DESCRIPTION
Fixes a warning when compiling without ncurses being installed.

Warning was produced when running:
$ ./configure --without-gtk
$ make
display.c: In function ‘display_keyaction’:
display.c:169:5: warning: ‘return’ with no value, in function returning non-void [-Wreturn-type]
     return mtr_curses_keyaction();
     ^