### PR TITLE
Fix and improvements for --csv 

### DIFF
--- a/asn.h
+++ b/asn.h
@@ -25,8 +25,9 @@
 // It will evaluate to nothing if we don't need it. 
 
 #ifndef NO_IPINFO
-#define IPINFO
 
+#ifndef IPINFO
+#define IPINFO
 
 extern int ipinfo_no;
 extern int ipinfo_max;
@@ -38,4 +39,5 @@ char *fmt_ipinfo(ip_t *addr);
 int get_iiwidth(void);
 int is_printii(void);
 
-#endif
+#endif /* IPINFO */
+#endif /* NO_IPINFO */

--- a/report.c
+++ b/report.c
@@ -365,9 +365,9 @@ void csv_close(time_t now)
 
       /* 1000.0 is a temporay hack for stats usec to ms, impacted net_loss. */
       if( index( data_fields[j].format, 'f' ) ) {
-	printf( ", %.2f", data_fields[j].net_xxx(at) / 1000.0);
+	printf( ",%.2f", data_fields[j].net_xxx(at) / 1000.0);
       } else {
-	printf( ", %d",   data_fields[j].net_xxx(at) );
+	printf( ",%d",   data_fields[j].net_xxx(at) );
       }
     }
     printf("\n");

--- a/report.c
+++ b/report.c
@@ -347,17 +347,31 @@ void csv_close(time_t now)
     addr = net_addr(at);
     snprint_addr(name, sizeof(name), addr);
 
-    int last = net_last(at);
+    if (at == net_min()) {
+      printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip,");
+#ifdef IPINFO
+      if(!ipinfo_no) {
+	printf("Asn,");
+      }
+#endif
+      for( i=0; i<MAXFLD; i++ ) {
+	j = fld_index[fld_active[i]];
+	if (j < 0) continue;
+	printf("%s,", data_fields[j].title);
+      }
+      printf("\n");
+    }
+
 #ifdef IPINFO
     if(!ipinfo_no) {
       char* fmtinfo = fmt_ipinfo(addr);
       if (fmtinfo != NULL) fmtinfo = trim(fmtinfo);
-      printf("MTR.%s;%lld;%s;%s;%d;%s;%s;%d", MTR_VERSION, (long long)now, "OK", Hostname,
-             at+1, name, fmtinfo, last);
+      printf("MTR.%s,%lld,%s,%s,%d,%s,%s", MTR_VERSION, (long long)now, "OK", Hostname,
+             at+1, name, fmtinfo);
     } else
 #endif
-      printf("MTR.%s;%lld;%s;%s;%d;%s;%d", MTR_VERSION, (long long)now, "OK", Hostname,
-             at+1, name, last);
+      printf("MTR.%s,%lld,%s,%s,%d,%s", MTR_VERSION, (long long)now, "OK", Hostname,
+             at+1, name);
 
     for( i=0; i<MAXFLD; i++ ) {
       j = fld_index[fld_active[i]];

--- a/report.c
+++ b/report.c
@@ -360,7 +360,7 @@ void csv_close(time_t now)
              at+1, name, last);
 
     for( i=0; i<MAXFLD; i++ ) {
-      j = fld_index[fld_active[j]];
+      j = fld_index[fld_active[i]];
       if (j < 0) continue; 
 
       /* 1000.0 is a temporay hack for stats usec to ms, impacted net_loss. */


### PR DESCRIPTION
There was a typo in csv_close() that prevented --csv from printing anything useful.

I also took the opportunity to add a csv header line to the printout, and changed every separator to a comma (rather than having the first entry be separated by semicolon.) These changes yield a csv file format that I personally find most convenient, in particular for post-processing by R. I hope they will be regarded as generally useful changes. 