### PR TITLE
Fix setting length field of UDP header to broken value on BSD systems.

### DIFF
--- a/net.c
+++ b/net.c
@@ -651,10 +651,8 @@ void net_send_query(int index)
       mypid += MinPort;
 
     udp->srcport = htons(mypid);
-    udp->length = abs(packetsize) - iphsize;
-    if(!BSDfix)
-      udp->length = htons(udp->length);
- 
+    udp->length = htons(abs(packetsize) - iphsize);
+
     udp->dstport = new_sequence(index);
     gettimeofday(&sequence[udp->dstport].time, NULL);
     udp->dstport = htons(udp->dstport);


### PR DESCRIPTION
As per http://stackoverflow.com/a/15881825 which references the manpage
ip(4) on *BSD and MacOSX:

  "The ip_len and ip_off fields must be provided in host byte order.
   All other fields must be provided in network byte order."

Before this commit, mtr would incorrectly set the length field of the UDP
header in host byte order after the first packet, as can be witnessed in
the following excerpt:

1st packet (TTL=1):

IP (tos 0x0, ttl 1, id 51530, offset 0, flags [none], proto UDP (17), length 64)
    192.168.178.61.1143 > 8.8.8.8.33000: UDP, *** length 36 ***
IP (tos 0xc0, ttl 64, id 34040, offset 0, flags [none], proto ICMP (1), length 92)
    192.168.178.1 > 192.168.178.61: ICMP time exceeded in-transit, length 72
      IP (tos 0x0, ttl 1, id 51530, offset 0, flags [none], proto UDP (17), length 64)
         192.168.178.61.1143 > 8.8.8.8.33000: UDP, length 36

2nd packet (TTL=2):

IP (tos 0x0, ttl 2, id 17256, offset 0, flags [none], proto UDP (17), length 64)
    192.168.178.61.1143 > 8.8.8.8.33001: UDP, *** bad length 11256 > 36 ***
IP (tos 0xc0, ttl 254, id 6765, offset 0, flags [none], proto ICMP (1), length 56)
    62.52.201.192 > 192.168.178.61: ICMP time exceeded in-transit, length 36
      IP (tos 0x0, ttl 1, id 17256, offset 0, flags [none], proto UDP (17), length 64)
         192.168.178.61.1143 > 8.8.8.8.33001: UDP, bad length 11256 > 36

3rd packet (TTL=3):

IP (tos 0x0, ttl 3, id 54343, offset 0, flags [none], proto UDP (17), length 64)
    192.168.178.61.1143 > 8.8.8.8.33002: UDP, *** bad length 11256 > 36 ***
IP (tos 0x0, ttl 253, id 0, offset 0, flags [none], proto ICMP (1), length 56)
    62.53.22.220 > 192.168.178.61: ICMP time exceeded in-transit, length 36
      IP (tos 0x0, ttl 1, id 54343, offset 0, flags [none], proto UDP (17), length 64)
         192.168.178.61.1143 > 8.8.8.8.33002: UDP, bad length 11256 > 36