### PR TITLE
Update asn.c - 32bit ASN widths

### DIFF
--- a/asn.c
+++ b/asn.c
@@ -60,7 +60,7 @@ char fmtinfo[32];
 extern int af;                  /* address family of remote target */
 
 // items width: ASN, Route, Country, Registry, Allocated 
-int iiwidth[] = { 6, 19, 4, 8, 11};	// item len + space
+int iiwidth[] = { 7, 19, 4, 8, 11};	// item len + space
 int iiwidth_len = sizeof(iiwidth)/sizeof((iiwidth)[0]);
 
 typedef char* items_t[ITEMSMAX + 1];


### PR DESCRIPTION
Now that 32-bit ASNs are becoming more common the output of -z should take their width into consideration.