### PR TITLE
Need to error check getnameinfo().

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -218,13 +218,13 @@ void dns_open(void)
 
         rv = getnameinfo  ((struct sockaddr *) &sa, salen, 
 			       hostname, sizeof (hostname), NULL, 0, 0);
+        if (rv == 0) {
+          sprintf (result, "%s %s\n", strlongip (&host), hostname);
+          //printf ("resolved: %s -> %s (%d)\n", strlongip (&host), hostname, rv);
+          rv = write (fromdns[1], result, strlen (result));
+          if (rv < 0) perror ("write DNS lookup result");
+        }
 
-        sprintf (result, "%s %s\n", strlongip (&host), hostname);
-
-        //printf ("resolved: %s -> %s (%d)\n", strlongip (&host), hostname, rv);
-
-        rv = write (fromdns[1], result, strlen (result));
-        if (rv < 0) perror ("write DNS lookup result");
         exit (0);
       }
     }


### PR DESCRIPTION
Noticed a problem on Debian returning garbage names when the getnameinfo() return code was -3, but this is applicable to any OS regardless.