### PR TITLE
Use setcap instead of setuid when installing the binary.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,8 @@ SUBDIRS = img
 sbin_PROGRAMS = mtr
 man_MANS = mtr.8
 install-exec-hook: 
-	chmod u+s $(DESTDIR)$(sbindir)/mtr
+	`setcap cap_net_raw+ep $(DESTDIR)$(sbindir)/mtr` \
+	|| chmod u+s $(DESTDIR)$(sbindir)/mtr
 
 mtr_SOURCES = mtr.c \
               net.c net.h \


### PR DESCRIPTION
Identical to PR #114 but this is for the newdns branch.