### PR TITLE
add max-unknown option

### DIFF
--- a/mtr.8
+++ b/mtr.8
@@ -80,6 +80,9 @@ mtr \- a network diagnostic tool
 .BI \-m \ MAX\-TTL\c
 ]
 [\c
+.BI \-U \ MAX\-UNKNOWN\c
+]
+[\c
 .B \-\-udp\c
 ]
 [\c
@@ -358,6 +361,9 @@ Specifies with what TTL to start.  Defaults to 1.
 .B \-m \fINUM\fR, \fB\-\-max-ttl \fINUM
 Specifies the maximum number of hops (max time-to-live value) traceroute will
 probe.  Default is 30.
+.TP
+.B \-U \fINUM\fR, \fB\-\-max-unknown \fINUM
+Specifies the maximum unknown host. Default is 5.
 .TP
 .B \-u\fR, \fB\-\-udp
 Use UDP datagrams instead of ICMP ECHO.

--- a/mtr.c
+++ b/mtr.c
@@ -88,6 +88,8 @@ int  fstTTL = 1;                /* default start at first hop */
 /*int maxTTL = MaxHost-1;  */     /* max you can go is 255 hops */
 int   maxTTL = 30;              /* inline with traceroute */
                                 /* end ttl window stuff. */
+int maxUnknown = 5;				/* stop send package */
+                                /*when larger than this count */
 int remoteport = 0;            /* for TCP tracing */
 int localport = 0;             /* for UDP tracing */
 int tcp_timeout = 10 * 1000000;     /* for TCP tracing */
@@ -303,6 +305,7 @@ void parse_arg (int argc, char **argv)
     { "address",        1, NULL, 'a' },
     { "first-ttl",      1, NULL, 'f' }, /* -f & -m are borrowed from traceroute */
     { "max-ttl",        1, NULL, 'm' },
+	{ "max-unknown",    1, NULL, 'U' },
     { "udp",            0, NULL, 'u' }, /* UDP (default is ICMP) */
     { "tcp",            0, NULL, 'T' }, /* TCP (default is ICMP) */
     { "sctp",           0, NULL, 'S' }, /* SCTP (default is ICMP) */
@@ -318,7 +321,7 @@ void parse_arg (int argc, char **argv)
   opt = 0;
   while(1) {
     opt = getopt_long(argc, argv,
-		      "hv46F:rwxtglCpnbo:y:zi:c:s:B:Q:ea:f:m:uTSP:L:Z:M:", long_options, NULL);
+		      "hv46F:rwxtglCpnbo:y:zi:c:s:B:Q:ea:f:m:U:uTSP:L:Z:M:", long_options, NULL);
     if(opt == -1)
       break;
 
@@ -410,6 +413,12 @@ void parse_arg (int argc, char **argv)
 	fstTTL = maxTTL;
       }
       break;
+	case 'U':
+		maxUnknown = atoi(optarg);
+		if (maxUnknown < 1) {
+			maxUnknown = 1;
+		}
+		break;
     case 'o':
       /* Check option before passing it on to fld_active. */
       if (strlen (optarg) > MAXFLD) {
@@ -631,7 +640,7 @@ int main(int argc, char **argv)
               "\t\t[--no-dns] [--show-ips] [-o FIELDS] [-y IPINFO] [--aslookup]\n"
               "\t\t[-i INTERVAL] [-c COUNT] [-s PACKETSIZE] [-B BITPATTERN]\n"
               "\t\t[-Q TOS] [--mpls]\n"
-              "\t\t[-a ADDRESS] [-f FIRST-TTL] [-m MAX-TTL]\n"
+              "\t\t[-a ADDRESS] [-f FIRST-TTL] [-m MAX-TTL] [-U MAX_UNKNOWN]\n"
               "\t\t[--udp] [--tcp] [--sctp] [-P PORT] [-L LOCALPORT] [-Z TIMEOUT]\n"
               "\t\t[-M MARK] HOSTNAME\n", argv[0]);
        printf("See the man page for details.\n");

--- a/net.c
+++ b/net.c
@@ -149,12 +149,6 @@ struct sequence {
 };
 
 
-/* Configuration parameter: How many queries to unknown hosts do we
-   send? (This limits the amount of traffic generated if a host is not
-   reachable) */
-#define MAX_UNKNOWN_HOSTS 5
-
-
 /* BSD-derived kernels use host byte order for the IP length and 
    offset fields when using raw sockets.  We detect this automatically at 
    run-time and do the right thing. */
@@ -209,6 +203,7 @@ static int numhosts = 10;
 
 extern int fstTTL;		/* initial hub(ttl) to ping byMin */
 extern int maxTTL;		/* last hub to ping byMin*/
+extern int maxUnknown;	/* stop ping threshold */
 extern int cpacketsize;		/* packet size used by ping */
 static int packetsize;		/* packet size used by ping */
 static int spacketsize;		/* packet size used by sendto */
@@ -1308,8 +1303,8 @@ int net_send_batch(void)
   if (	/* success in reaching target */
      ( addrcmp( (void *) &(host[batch_at].addr),
                 (void *) remoteaddress, af ) == 0 ) ||
-      /* fail in consecutive MAX_UNKNOWN_HOSTS (firewall?) */
-      (n_unknown > MAX_UNKNOWN_HOSTS) ||
+      /* fail in consecutive maxUnknown (firewall?) */
+      (n_unknown > maxUnknown) ||
       /* or reach limit  */
       (batch_at >= maxTTL-1)) {
     numhosts = batch_at+1;


### PR DESCRIPTION
remove the MAX_UNKNOWN_HOSTS macro, use maxUnknown variable
instead of it, and add --max-unknown option, let it can be
configured at run time.

I hit the limit of MAX_UNKNOWN_HOSTS, my test path has 6 unknown host, So I should recompiled mtr and in crease the value of MAX_UNKNOWN_HOSTS. I hope mtr can support to adjust this value at run time.