### PR TITLE
Change default --max-unknown from 5 to 12 for large cloud networks

### DIFF
--- a/mtr.c
+++ b/mtr.c
@@ -89,8 +89,8 @@ int  fstTTL = 1;                /* default start at first hop */
 /*int maxTTL = MaxHost-1;  */     /* max you can go is 255 hops */
 int   maxTTL = 30;              /* inline with traceroute */
                                 /* end ttl window stuff. */
-int maxUnknown = 5;				/* stop send package */
-                                /*when larger than this count */
+int maxUnknown = 12;            /* stop send package */
+                                /* when larger than this count */
 int remoteport = 0;            /* for TCP tracing */
 int localport = 0;             /* for UDP tracing */
 int tcp_timeout = 10 * 1000000;     /* for TCP tracing */


### PR DESCRIPTION
Fix the PR #104 to fit the new implementation. 

> updated net.c to 12 to fix cloud network timeouts
>
> Updated MAX_UNKNOWN_HOSTS to 12, from 5. Have been hearing of issues where -f is becoming default/required in some larger cloud networks. This value allows mtr to work in all tested cases again without -f and gives head room for additional network growth.
> 
> ...This default value needs to be higher to support cloud provider networks and their growth. Else when clouds are adding additional network devices MTR is starting to break in same cases due to their internal hops. Through testing with various cloud providers, 12 is a safe number to ensure we don't hit this issue for many more years to come. It adds minimal overhead on the existing infrastructure.
