### PR TITLE
Pkg config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ mtr_SOURCES = mtr.c mtr.h \
               img/mtr_icon.xpm \
               mtr-gtk.h
 
-if IPINFO
+if WITH_IPINFO
 mtr_SOURCES += asn.c asn.h
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,14 +23,14 @@ if IPINFO
 mtr_SOURCES += asn.c asn.h
 endif
 
-EXTRA_mtr_SOURCES = curses.c
+if WITH_NCURSES
+mtr_SOURCES += curses.c
+endif
 
 if WITH_GTK
 mtr_SOURCES += gtk.c
 endif
 
-mtr_DEPENDENCIES = $(CURSES_OBJ)
-mtr_LDFLAGS = $(CURSES_OBJ)
 mtr_INCLUDES = $(GLIB_CFLAGS) -I$(top_builddir) -I$(top_srcdir)
 mtr_CFLAGS = $(GTK_CFLAGS) $(NCURSES_CFLAGS)
-mtr_LDADD = $(GTK_LIBS) $(NCURSES_LDADD) $(RESOLV_LIBS)
+mtr_LDADD = $(GTK_LIBS) $(NCURSES_LIBS) $(RESOLV_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,10 +23,14 @@ if IPINFO
 mtr_SOURCES += asn.c asn.h
 endif
 
-EXTRA_mtr_SOURCES = curses.c \
-                    gtk.c
+EXTRA_mtr_SOURCES = curses.c
 
+if WITH_GTK
+mtr_SOURCES += gtk.c
+endif
+
+mtr_DEPENDENCIES = $(CURSES_OBJ)
+mtr_LDFLAGS = $(CURSES_OBJ)
 mtr_INCLUDES = $(GLIB_CFLAGS) -I$(top_builddir) -I$(top_srcdir)
-mtr_DEPENDENCIES = $(GTK_OBJ) $(CURSES_OBJ)
-mtr_LDFLAGS = $(GTK_OBJ) $(CURSES_OBJ)
-mtr_LDADD = $(GLIB_LIBS) $(RESOLV_LIBS)
+mtr_CFLAGS = $(GTK_CFLAGS) $(NCURSES_CFLAGS)
+mtr_LDADD = $(GTK_LIBS) $(NCURSES_LDADD) $(RESOLV_LIBS)

--- a/asn.h
+++ b/asn.h
@@ -16,19 +16,6 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-// The autoconf system provides us with the NO_IPINFO define. 
-// Littering the code with #ifndef NO_IPINFO (double negative)
-// does not benefit readability. So here we invert the sense of the
-// define. 
-//
-// Similarly, this include file should be included unconditionally. 
-// It will evaluate to nothing if we don't need it. 
-
-#ifndef NO_IPINFO
-
-#ifndef IPINFO
-#define IPINFO
-
 extern int ipinfo_no;
 extern int ipinfo_max;
 extern int iiwidth_len;
@@ -38,6 +25,3 @@ void asn_close();
 char *fmt_ipinfo(ip_t *addr);
 int get_iiwidth(void);
 int is_printii(void);
-
-#endif /* IPINFO */
-#endif /* NO_IPINFO */

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-aclocal
+aclocal $ACLOCAL_OPTS
 autoheader
 automake --add-missing --copy --foreign
 autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,6 @@ m4_ifdef([AM_SILENT_RULES],
   [AM_SILENT_RULES([yes])],
   [AC_SUBST([AM_DEFAULT_VERBOSITY], [1])])
 
-AC_SUBST([CURSES_OBJ])
-CURSES_OBJ=curses.o
-
 AC_PROG_CC
 
 # Check pkg-config availability.
@@ -50,24 +47,8 @@ AC_CHECK_HEADERS([ \
   sys/xti.h \
 ])
 
-# Find ncursses.
-AC_SEARCH_LIBS([initscr],
-  [ncurses curses cursesX],
-  [],
-  [AC_MSG_WARN([Building without curses display support])
-  AC_DEFINE([NO_CURSES], [1], [Define if you don't have the curses libraries available.])
-  CURSES_OBJ=])
-
-AC_CHECK_LIB([ncurses],
-  [use_default_colors],
-  [AC_DEFINE([HAVE_USE_DEFAULT_COLORS],
-    [1],
-    [Define this if your curses library has the use_default_colors() command.])
-  ])
-
 # Check functions.
 AC_CHECK_FUNCS([ \
-  attron \
   fcntl \
 ])
 
@@ -83,6 +64,24 @@ AS_IF([test "x$with_gtk" = "xyes"],
     [with_gtk=no])
 ])
 AM_CONDITIONAL([WITH_GTK], [test "x$with_gtk" = xyes])
+
+# Find ncurses
+AC_ARG_WITH([ncurses],
+  [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
+  [], [with_ncurses=yes])
+AS_IF([test "x$with_ncurses" = "xyes"],
+  [PKG_CHECK_MODULES([NCURSES], [ncurses], [
+      AC_DEFINE([HAVE_NCURSES], [1], [Define if ncurses library available])
+      AC_CHECK_LIB([ncurses],
+        [use_default_colors],
+        [AC_DEFINE([HAVE_USE_DEFAULT_COLORS], [1],
+          [Define this if your curses library has the use_default_colors() command.]
+        )
+      ])
+    ],
+    [with_ncurses=no])
+])
+AM_CONDITIONAL([WITH_NCURSES], [test "x$with_ncurses" = xyes])
 
 # Enable ipinfo
 AC_ARG_WITH([ipinfo],

--- a/configure.ac
+++ b/configure.ac
@@ -110,62 +110,20 @@ AC_CHECK_FUNC([socket], [],
 AC_CHECK_FUNC([gethostbyname], [],
   [AC_CHECK_LIB([nsl], [gethostbyname], [], [AC_MSG_ERROR([No nameservice library found])])])
 
-dnl AC_CHECK_FUNC([res_init], [], [
-dnl   AC_CHECK_LIB([bind], [res_init], [], [
-dnl   AC_CHECK_LIB([resolv], [res_init], [], [AC_MSG_ERROR([No resolver library found])])])])
-
 AC_CHECK_FUNCS([seteuid])
 dnl  AC_CHECK_FUNC([setuid], [], [AC_MSG_ERROR([I Need either seteuid or setuid])])
 
-dnl AC_CHECK_FUNC([res_mkquery], [], [
-dnl   AC_CHECK_LIB([bind], [res_mkquery], , [
-dnl    AC_CHECK_LIB([resolv], [res_mkquery], [], [
-dnl      AC_CHECK_LIB([resolv], [__res_mkquery], [],
-dnl        [AC_MSG_ERROR([No resolver library found])
-dnl      ])
-dnl    ])
-dnl  ])
-dnl ])
-
-# See if a library is needed for res_mkquery and if so put it in RESOLV_LIBS
-RESOLV_LIBS=
-AC_SUBST([RESOLV_LIBS])
-AC_DEFUN([LIBRESOLVTEST_SRC], [
-AC_LANG_PROGRAM([[
-#include <netinet/in.h>
-#include <resolv.h>
-]], [[
-int (*res_mkquery_func)(int,...) = (int (*)(int,...))res_mkquery;
-(void)(*res_mkquery_func)(0);
-]])])
-AC_MSG_CHECKING([whether library required for res_mkquery])
-RESOLV_LIB_NONE=
-AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
-  [AC_MSG_RESULT([no])
-  RESOLV_LIB_NONE=yes],
-  [AC_MSG_RESULT([yes])])
-
-AS_IF([test "x$RESOLV_LIB_NONE" = "x"], [
-  AC_MSG_CHECKING([for res_mkquery in -lbind])
-  STASH_LIBS="$LIBS"
-  LIBS="$STASH_LIBS -lbind"
-  AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
-    [AC_MSG_RESULT([yes])
-    RESOLV_LIBS=-lbind],
-    [AC_MSG_RESULT([no])
-  ])
-  AS_IF([test "x$RESOLV_LIBS" = "x"], [
-    AC_MSG_CHECKING([for res_mkquery in -lresolv])
-    LIBS="$STASH_LIBS -lresolv"
-    AC_LINK_IFELSE([LIBRESOLVTEST_SRC],
-    [AC_MSG_RESULT([yes])
-    RESOLV_LIBS=-lresolv],
-    [AC_MSG_RESULT([no])
-      AC_MSG_ERROR([No resolver library found])
+# Find resolver library.
+AC_CHECK_FUNC([res_query], [RESOLV_LIBS=""], [
+  AC_CHECK_LIB([resolv], [__res_query], [RESOLV_LIBS="-lresolv"], [
+    AC_CHECK_LIB([resolv], [res_query], [RESOLV_LIBS="-lresolv"], [
+      AC_CHECK_LIB([bind], [res_query], [RESOLV_LIBS="-lbind"], [
+        AC_MSG_ERROR([No resolver library found])
+      ])
     ])
   ])
-  LIBS="$STASH_LIBS"
 ])
+AC_SUBST([RESOLV_LIBS])
 
 # Error printing functions.
 AC_CHECK_FUNC([herror], [],

--- a/configure.ac
+++ b/configure.ac
@@ -122,10 +122,7 @@ AC_CHECK_FUNC([res_query], [RESOLV_LIBS=""], [
 ])
 AC_SUBST([RESOLV_LIBS])
 
-# Error printing functions.
-AC_CHECK_FUNC([herror], [],
-  [AC_DEFINE([NO_HERROR], [1], [Define if you don't have the herror() function available.])])
-
+# Check errno and socket data types.
 AC_CHECK_DECLS([errno], [], [], [[
 #include <errno.h>
 #include <sys/errno.h>

--- a/configure.ac
+++ b/configure.ac
@@ -15,10 +15,7 @@ m4_ifdef([AM_SILENT_RULES],
   [AM_SILENT_RULES([yes])],
   [AC_SUBST([AM_DEFAULT_VERBOSITY], [1])])
 
-AC_SUBST([GTK_OBJ])
 AC_SUBST([CURSES_OBJ])
-
-GTK_OBJ=gtk.o
 CURSES_OBJ=curses.o
 
 AC_PROG_CC
@@ -78,34 +75,14 @@ AC_CHECK_LIB([m], [floor], [], [AC_MSG_ERROR([No math library found])])
 
 # Find GTK
 AC_ARG_WITH([gtk],
-  [AS_HELP_STRING([--without-gtk], [Do not try to use GTK+ at all])],
+  [AS_HELP_STRING([--without-gtk], [Build without the GTK+2.0 interface])],
   [], [with_gtk=yes])
-AS_IF([test "x$with_gtk" = "xyes"], [WANTS_GTK=yes], [WANTS_GTK=no])
-
-m4_ifndef([AM_PATH_GTK_2_0],
-  [m4_defun([AM_PATH_GTK_2_0], [
-    AC_MSG_ERROR([dnl
-Could not locate the gtk2 automake macros, these are usually located in
-  .../share/aclocal/gtk-2.0.m4
-Before running bootstrap try setting the environment variable
-  ACLOCAL_PATH="/own/dir"
-or configure --without-gtk.])
-  ])
+AS_IF([test "x$with_gtk" = "xyes"],
+  [PKG_CHECK_MODULES([GTK], [gtk+-2.0],
+    [AC_DEFINE([HAVE_GTK], [1], [Define if gtk+-2.0 library available])],
+    [with_gtk=no])
 ])
-
-AS_IF([test "x$WANTS_GTK" = "xyes"], [
-  AM_PATH_GTK_2_0([2.6.0], [
-    CFLAGS="$CFLAGS $GTK_CFLAGS"
-    LIBS="$LIBS $GTK_LIBS -lm"
-  ], [
-    AC_MSG_WARN([Building without GTK2 display support])
-    AC_DEFINE([NO_GTK], [1], [Define if you don't have the GTK+ libraries available.])
-    GTK_OBJ=""
-  ])
-], [
-  AC_DEFINE([NO_GTK], [1], [Define if you don't have the GTK+ libraries available.])
-  GTK_OBJ=""
-])
+AM_CONDITIONAL([WITH_GTK], [test "x$with_gtk" = xyes])
 
 # Enable ipinfo
 AC_ARG_WITH([ipinfo],

--- a/configure.ac
+++ b/configure.ac
@@ -110,9 +110,6 @@ AC_CHECK_FUNC([socket], [],
 AC_CHECK_FUNC([gethostbyname], [],
   [AC_CHECK_LIB([nsl], [gethostbyname], [], [AC_MSG_ERROR([No nameservice library found])])])
 
-AC_CHECK_FUNCS([seteuid])
-dnl  AC_CHECK_FUNC([setuid], [], [AC_MSG_ERROR([I Need either seteuid or setuid])])
-
 # Find resolver library.
 AC_CHECK_FUNC([res_query], [RESOLV_LIBS=""], [
   AC_CHECK_LIB([resolv], [__res_query], [RESOLV_LIBS="-lresolv"], [
@@ -128,8 +125,6 @@ AC_SUBST([RESOLV_LIBS])
 # Error printing functions.
 AC_CHECK_FUNC([herror], [],
   [AC_DEFINE([NO_HERROR], [1], [Define if you don't have the herror() function available.])])
-AC_CHECK_FUNC([strerror], [],
-  [AC_DEFINE([NO_STRERROR], [1], [Define if you don't have the strerror() function available.])])
 
 AC_CHECK_DECLS([errno], [], [], [[
 #include <errno.h>
@@ -145,10 +140,6 @@ AC_CHECK_TYPE([socklen_t],
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif]])
-
-AC_CHECK_TYPE([struct in_addr],
-  [AC_DEFINE([HAVE_STRUCT_INADDR], [], [Define if you have struct in_addr])], [],
-  [[#include <netinet/in.h>]])
 
 # Add C flags to display more warnings
 AC_MSG_CHECKING([for C flags to get more warnings])

--- a/configure.ac
+++ b/configure.ac
@@ -87,9 +87,9 @@ AM_CONDITIONAL([WITH_NCURSES], [test "x$with_ncurses" = xyes])
 AC_ARG_WITH([ipinfo],
   [AS_HELP_STRING([--without-ipinfo], [Do not try to use ipinfo lookup at all])],
   [], [with_ipinfo=yes])
-AM_CONDITIONAL([IPINFO], [test "x$with_ipinfo" = "xyes"])
-AS_IF([test "x$with_ipinfo" = "xno"], [
-  AC_DEFINE([NO_IPINFO], [1], [Define to disable ipinfo lookup])
+AM_CONDITIONAL([WITH_IPINFO], [test "x$with_ipinfo" = "xyes"])
+AS_IF([test "x$with_ipinfo" = "xyes"], [
+  AC_DEFINE([HAVE_IPINFO], [1], [Define when ipinfo lookups are in use])
 ])
 
 AC_ARG_ENABLE([ipv6],

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,16 @@ CURSES_OBJ=curses.o
 
 AC_PROG_CC
 
+# Check pkg-config availability.
+m4_ifndef([PKG_PROG_PKG_CONFIG],
+  [m4_fatal(
+[Could not locate the pkg-config autoconf macros.  These are usually located
+in /usr/share/aclocal/pkg.m4.  If your macros are in a different location,
+try setting the environment variable ACLOCAL_OPTS="-I/other/macro/dir"
+before running ./bootstrap.sh again.])
+])
+PKG_PROG_PKG_CONFIG
+
 # Check bytes in types.
 AC_CHECK_SIZEOF([unsigned char], [1])
 AC_CHECK_SIZEOF([unsigned short], [2])

--- a/curses.c
+++ b/curses.c
@@ -150,7 +150,7 @@ int mtr_curses_keyaction(void)
     return ActionMPLS;
   if (tolower(c) == 'n')
     return ActionDNS;
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
   if (tolower(c) == 'y')
     return ActionII;
   if (tolower(c) == 'z')
@@ -333,7 +333,7 @@ int mtr_curses_keyaction(void)
     printw("  b <c>   set ping bit pattern to c(0..255) or random(c<0)\n" );
     printw("  Q <t>   set ping packet's TOS to t\n" );
     printw("  u       switch between ICMP ECHO and UDP datagrams\n" );
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     printw("  y       switching IP info\n");
     printw("  z       toggle ASN info on/off\n");
     pressanykey_row += 2;
@@ -388,7 +388,7 @@ void mtr_curses_hosts(int startstat)
       name = dns_lookup(addr);
       if (! net_up(at))
 	attron(A_BOLD);
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
       if (is_printii())
         printw(fmt_ipinfo(addr));
 #endif
@@ -437,7 +437,7 @@ void mtr_curses_hosts(int startstat)
         name = dns_lookup(addrs);
         if (! net_up(at)) attron(A_BOLD);
         printw("\n    ");
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
         if (is_printii())
           printw(fmt_ipinfo(addrs));
 #endif
@@ -600,7 +600,7 @@ void mtr_curses_graph(int startstat, int cols)
 		if (! net_up(at))
 			attron(A_BOLD);
 		if (addrcmp((void *) addr, (void *) &unspec_addr, af)) {
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
 			if (is_printii())
 				printw(fmt_ipinfo(addr));
 #endif
@@ -690,7 +690,7 @@ void mtr_curses_redraw(void)
   } else {
     char msg[80];
     int padding = 30;
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     if (is_printii())
       padding += get_iiwidth();
 #endif

--- a/curses.c
+++ b/curses.c
@@ -21,7 +21,7 @@
 #include <strings.h>
 #include <unistd.h>
 
-#ifndef NO_CURSES
+#ifdef HAVE_NCURSES
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,11 +48,6 @@
 #  include <cursesX.h>
 #else
 #  error No curses header file available
-#endif
-
-#ifndef HAVE_ATTRON
-#define attron(x) 
-#define attroff(x) 
 #endif
 
 #ifndef getmaxyx

--- a/display.c
+++ b/display.c
@@ -66,7 +66,7 @@ extern int DisplayMode;
 #include "split.h"
 #endif
 
-#ifndef IPINFO
+#ifndef HAVE_IPINFO
 // No support for IPINFO allow the calls to remain in the main code.
 #define asn_open()
 #define asn_close()

--- a/display.c
+++ b/display.c
@@ -34,15 +34,15 @@
 
 extern int DisplayMode;
 
-#ifdef NO_CURSES
+#ifdef HAVE_NCURSES
+#include "mtr-curses.h"
+#else
 // No support for curses mode, allow the calls to remain in the code.
 #define mtr_curses_open()
 #define mtr_curses_close()
 #define mtr_curses_redraw()
 #define mtr_curses_keyaction() 0
 #define mtr_curses_clear()
-#else
-#include "mtr-curses.h"
 #endif
 
 #ifdef HAVE_GTK
@@ -72,10 +72,10 @@ extern int DisplayMode;
 #define asn_close()
 #endif
 
-#ifdef NO_CURSES
-#define DEFAULT_DISPLAY DisplayReport
-#else
+#ifdef HAVE_NCURSES
 #define DEFAULT_DISPLAY DisplayCurses
+#else
+#define DEFAULT_DISPLAY DisplayReport
 #endif
 
 #ifdef HAVE_GTK

--- a/display.c
+++ b/display.c
@@ -56,15 +56,7 @@ extern int DisplayMode;
 #define gtk_loop() {fprintf (stderr, "No GTK support. Sorry.\n"); exit(EXIT_FAILURE); }
 #endif
 
-#ifdef NO_SPLIT
-// No support for split mode, allow the calls to remain in the code.
-#define split_open()
-#define split_close()
-#define split_redraw()
-#define split_keyaction() 0
-#else
 #include "split.h"
-#endif
 
 #ifndef HAVE_IPINFO
 // No support for IPINFO allow the calls to remain in the main code.

--- a/display.c
+++ b/display.c
@@ -45,15 +45,15 @@ extern int DisplayMode;
 #include "mtr-curses.h"
 #endif
 
-#ifdef NO_GTK
+#ifdef HAVE_GTK
+#include "mtr-gtk.h"
+#else
 // No support for gtk mode, allow the calls to remain in the code.
 #define gtk_open()
 #define gtk_close()
 #define gtk_redraw()
 #define gtk_keyaction() 0
 #define gtk_loop() {fprintf (stderr, "No GTK support. Sorry.\n"); exit(EXIT_FAILURE); }
-#else
-#include "mtr-gtk.h"
 #endif
 
 #ifdef NO_SPLIT
@@ -78,17 +78,17 @@ extern int DisplayMode;
 #define DEFAULT_DISPLAY DisplayCurses
 #endif
 
-#ifdef NO_GTK
-#define UNUSED_IF_NO_GTK UNUSED
-#else
+#ifdef HAVE_GTK
 #define UNUSED_IF_NO_GTK
+#else
+#define UNUSED_IF_NO_GTK UNUSED
 #endif
 
 void display_detect(int *argc UNUSED_IF_NO_GTK, char ***argv UNUSED_IF_NO_GTK)
 {
   DisplayMode = DEFAULT_DISPLAY;
 
-#ifndef NO_GTK
+#ifdef HAVE_GTK
   if(gtk_detect(argc, argv)) {
     DisplayMode = DisplayGTK;
   }

--- a/display.c
+++ b/display.c
@@ -36,33 +36,13 @@ extern int DisplayMode;
 
 #ifdef HAVE_NCURSES
 #include "mtr-curses.h"
-#else
-// No support for curses mode, allow the calls to remain in the code.
-#define mtr_curses_open()
-#define mtr_curses_close()
-#define mtr_curses_redraw()
-#define mtr_curses_keyaction() 0
-#define mtr_curses_clear()
 #endif
 
 #ifdef HAVE_GTK
 #include "mtr-gtk.h"
-#else
-// No support for gtk mode, allow the calls to remain in the code.
-#define gtk_open()
-#define gtk_close()
-#define gtk_redraw()
-#define gtk_keyaction() 0
-#define gtk_loop() {fprintf (stderr, "No GTK support. Sorry.\n"); exit(EXIT_FAILURE); }
 #endif
 
 #include "split.h"
-
-#ifndef HAVE_IPINFO
-// No support for IPINFO allow the calls to remain in the main code.
-#define asn_open()
-#define asn_close()
-#endif
 
 #ifdef HAVE_NCURSES
 #define DEFAULT_DISPLAY DisplayCurses
@@ -107,17 +87,25 @@ void display_open(void)
   case DisplayCSV:
     csv_open();
     break;
+#ifdef HAVE_NCURSES
   case DisplayCurses:
     mtr_curses_open();  
+#ifdef HAVE_IPINFO
     asn_open();
+#endif
     break;
+#endif
   case DisplaySplit:
     split_open();
     break;
+#ifdef HAVE_GTK
   case DisplayGTK:
     gtk_open();
+#ifdef HAVE_IPINFO
     asn_open();
+#endif
     break;
+#endif
   }
 }
 
@@ -140,16 +128,22 @@ void display_close(time_t now)
   case DisplayCSV:
     csv_close(now);
     break;
+#ifdef HAVE_NCURSES
   case DisplayCurses:
+#ifdef HAVE_IPINFO
     asn_close();
+#endif
     mtr_curses_close();
     break;
+#endif
   case DisplaySplit:
     split_close();
     break;
+#ifdef HAVE_GTK
   case DisplayGTK:
     gtk_close();
     break;
+#endif
   }
 }
 
@@ -158,17 +152,21 @@ void display_redraw(void)
 {
   switch(DisplayMode) {
 
+#ifdef HAVE_NCURSES
   case DisplayCurses:
     mtr_curses_redraw();
     break;
+#endif
 
   case DisplaySplit:
     split_redraw();
     break;
 
+#ifdef HAVE_GTK
   case DisplayGTK:
     gtk_redraw();
     break;
+#endif
   }
 }
 
@@ -176,14 +174,18 @@ void display_redraw(void)
 int display_keyaction(void)
 {
   switch(DisplayMode) {
+#ifdef HAVE_NCURSES
   case DisplayCurses:
     return mtr_curses_keyaction();
+#endif
 
   case DisplaySplit:
     return split_keyaction();
 
+#ifdef HAVE_GTK
   case DisplayGTK:
     return gtk_keyaction();
+#endif
   }
   return 0;
 }
@@ -208,8 +210,12 @@ void display_rawping(int host, int msec, int seq)
   case DisplayXML:
   case DisplayCSV:
   case DisplaySplit:
+#ifdef HAVE_NCURSES
   case DisplayCurses:
+#endif
+#ifdef HAVE_GTK
   case DisplayGTK:
+#endif
     break;
   case DisplayRaw:
     raw_rawping (host, msec, seq);
@@ -227,8 +233,12 @@ void display_rawhost(int host, ip_t *ip_addr)
   case DisplayXML:
   case DisplayCSV:
   case DisplaySplit:
+#ifdef HAVE_NCURSES
   case DisplayCurses:
+#endif
+#ifdef HAVE_GTK
   case DisplayGTK:
+#endif
     break;
   case DisplayRaw:
     raw_rawhost (host, ip_addr);
@@ -246,13 +256,17 @@ void display_loop(void)
   case DisplayXML:
   case DisplayCSV:
   case DisplaySplit:
+#ifdef HAVE_NCURSES
   case DisplayCurses:
+#endif
   case DisplayRaw:
     select_loop();
     break;
+#ifdef HAVE_GTK
   case DisplayGTK:
     gtk_loop();
     break;
+#endif
   }
 }
 
@@ -260,9 +274,11 @@ void display_loop(void)
 void display_clear(void)
 {
   switch(DisplayMode) {
+#ifdef HAVE_NCURSES
   case DisplayCurses:
     mtr_curses_clear();
     break;
+#endif
   case DisplayReport:
   case DisplayTXT:
   case DisplayJSON:
@@ -272,7 +288,9 @@ void display_clear(void)
   case DisplayRaw:
     break;
 
+#ifdef HAVE_GTK
   case DisplayGTK:
     break;
+#endif
   }
 }

--- a/display.h
+++ b/display.h
@@ -22,7 +22,7 @@
    (notably the one on Irix 5.2) do not like that. */ 
 enum { ActionNone,  ActionQuit,  ActionReset,  ActionDisplay, 
        ActionClear, ActionPause, ActionResume, ActionMPLS, ActionDNS, 
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
        ActionII, ActionAS,
 #endif
        ActionScrollDown, ActionScrollUp  };

--- a/display.h
+++ b/display.h
@@ -26,8 +26,22 @@ enum { ActionNone,  ActionQuit,  ActionReset,  ActionDisplay,
        ActionII, ActionAS,
 #endif
        ActionScrollDown, ActionScrollUp  };
-enum { DisplayReport, DisplayCurses, DisplayGTK, DisplaySplit, 
-       DisplayRaw,    DisplayXML,    DisplayCSV, DisplayTXT, DisplayJSON};
+
+enum {
+  DisplayReport,
+#ifdef HAVE_NCURSES
+  DisplayCurses,
+#endif
+#ifdef HAVE_GTK
+  DisplayGTK,
+#endif
+  DisplaySplit,
+  DisplayRaw,
+  DisplayXML,
+  DisplayCSV,
+  DisplayTXT,
+  DisplayJSON
+};
 
 /*  Prototypes for display.c  */
 void display_detect(int *argc, char ***argv);

--- a/gtk.c
+++ b/gtk.c
@@ -287,7 +287,7 @@ static GtkWidget *ReportTreeView;
 static GtkListStore *ReportStore;
 
 enum {
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
   COL_ASN,
 #endif
   COL_HOSTNAME,
@@ -343,7 +343,7 @@ void TreeViewCreate(void)
   GtkTreeViewColumn *column;
 
   ReportStore = gtk_list_store_new(N_COLS,
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     G_TYPE_STRING,
 #endif
     G_TYPE_STRING,
@@ -363,7 +363,7 @@ void TreeViewCreate(void)
   g_signal_connect(GTK_OBJECT(ReportTreeView), "button_press_event", 
   		    G_CALLBACK(ReportTreeView_clicked),NULL);
 
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
   if (is_printii()) {
     renderer = gtk_cell_renderer_text_new ();
     column = gtk_tree_view_column_new_with_attributes ("ASN",
@@ -491,7 +491,7 @@ void update_tree_row(int row, GtkTreeIter *iter)
     COL_COLOR, net_up(row) ? "black" : "red",
 
     -1);
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
   if (is_printii())
     gtk_list_store_set(ReportStore, iter, COL_ASN, fmt_ipinfo(addr), -1);
 #endif

--- a/gtk.c
+++ b/gtk.c
@@ -25,7 +25,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
-#ifndef NO_GTK
+#ifdef HAVE_GTK
 #include <string.h>
 #include <sys/types.h>
 #include <gtk/gtk.h>

--- a/mtr.c
+++ b/mtr.c
@@ -340,7 +340,7 @@ void parse_arg (int argc, char **argv)
     { "no-dns",         0, NULL, 'n' },
     { "show-ips",       0, NULL, 'b' },
     { "order",          1, NULL, 'o' }, /* fields to display & their order */
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     { "ipinfo",         1, NULL, 'y' }, /* IP info lookup */
     { "aslookup",       0, NULL, 'z' }, /* Do AS lookup (--ipinfo 0) */
 #endif
@@ -570,7 +570,7 @@ void parse_arg (int argc, char **argv)
       fprintf( stderr, "IPv6 not enabled.\n" );
       break;
 #endif
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     case 'y':
       ipinfo_no = atoi (optarg);
       if (ipinfo_no < 0)

--- a/mtr.c
+++ b/mtr.c
@@ -53,11 +53,6 @@
 #endif
 
 
-#ifdef NO_HERROR
-#define herror(str) fprintf(stderr, str ": error looking up \"%s\"\n", Hostname);
-#endif
-
-
 int   DisplayMode;
 int   display_mode;
 int   Interactive = 1;
@@ -642,12 +637,12 @@ int main(int argc, char **argv)
 {
   struct hostent *  host                = NULL;
   int               net_preopen_result;
-#ifdef ENABLE_IPV6
   struct addrinfo       hints, *res;
   int                   error;
   struct hostent        trhost;
   char *                alptr[2];
   struct sockaddr_in *  sa4;
+#ifdef ENABLE_IPV6
   struct sockaddr_in6 * sa6;
 #endif
 
@@ -726,7 +721,6 @@ int main(int argc, char **argv)
       }
     }
 
-#ifdef ENABLE_IPV6
     /* gethostbyname2() is deprecated so we'll use getaddrinfo() instead. */
     memset( &hints, 0, sizeof hints );
     hints.ai_family = af;
@@ -758,10 +752,12 @@ int main(int argc, char **argv)
       sa4 = (struct sockaddr_in *) res->ai_addr;
       alptr[0] = (void *) &(sa4->sin_addr);
       break;
+#ifdef ENABLE_IPV6
     case AF_INET6:
       sa6 = (struct sockaddr_in6 *) res->ai_addr;
       alptr[0] = (void *) &(sa6->sin6_addr);
       break;
+#endif
     default:
       fprintf( stderr, "mtr unknown address type\n" );
       if ( DisplayMode != DisplayCSV ) exit(EXIT_FAILURE);
@@ -771,18 +767,6 @@ int main(int argc, char **argv)
       }
     }
     alptr[1] = NULL;
-#else
-      host = gethostbyname(Hostname);
-    if (host == NULL) {
-      herror("mtr gethostbyname");
-      if ( DisplayMode != DisplayCSV ) exit(EXIT_FAILURE);
-      else {
-        names = names->next;
-        continue;
-      }
-    }
-    af = host->h_addrtype;
-#endif
 
     if (net_open(host) != 0) {
       fprintf(stderr, "mtr: Unable to start net module.\n");

--- a/report.c
+++ b/report.c
@@ -71,7 +71,7 @@ static size_t snprint_addr(char *dst, size_t dst_len, ip_t *addr)
 }
 
 
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
 void print_mpls(struct mplslen *mpls) {
   int k;
   for (k=0; k < mpls->labels; k++)
@@ -106,7 +106,7 @@ void report_close(void)
     }
   }
   
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
   int len_tmp = len_hosts;
   if (ipinfo_no >= 0) {
     ipinfo_no %= iiwidth_len;
@@ -140,7 +140,7 @@ void report_close(void)
     mpls = net_mpls(at);
     snprint_addr(name, sizeof(name), addr);
 
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     if (is_printii()) {
       snprintf(fmt, sizeof(fmt), " %%2d. %%s%%-%zus", len_hosts);
       snprintf(buf, sizeof(buf), fmt, at+1, fmt_ipinfo(addr), name);
@@ -148,7 +148,7 @@ void report_close(void)
 #endif
     snprintf( fmt, sizeof(fmt), " %%2d.|-- %%-%zus", len_hosts);
     snprintf(buf, sizeof(buf), fmt, at+1, name);
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     }
 #endif
     len = reportwide ? strlen(buf) : len_hosts;  
@@ -186,7 +186,7 @@ void report_close(void)
 
       if (!found) {
   
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
         if (is_printii()) {
           if (mpls->labels && z == 1 && enablempls)
             print_mpls(mpls);
@@ -215,14 +215,14 @@ void report_close(void)
           }
         }
 #endif
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
         }
 #endif
       }
     }
 
     /* No multipath */
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     if (is_printii()) {
       if (mpls->labels && z == 1 && enablempls)
         print_mpls(mpls);
@@ -235,7 +235,7 @@ void report_close(void)
       }
     }
 #endif
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     }
 #endif
   }
@@ -437,7 +437,7 @@ void csv_close(time_t now)
 
     if (at == net_min()) {
       printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip,");
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
       if(!ipinfo_no) {
 	printf("Asn,");
       }
@@ -450,7 +450,7 @@ void csv_close(time_t now)
       printf("\n");
     }
 
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
     if(!ipinfo_no) {
       char* fmtinfo = fmt_ipinfo(addr);
       fmtinfo = trim(fmtinfo);

--- a/select.c
+++ b/select.c
@@ -237,7 +237,7 @@ void select_loop(void) {
 	  display_clear();
 	}
 	break;
-#ifdef IPINFO
+#ifdef HAVE_IPINFO
       case ActionII:
 	ipinfo_no++;
 	if (ipinfo_no > ipinfo_max)

--- a/split.c
+++ b/split.c
@@ -35,23 +35,20 @@
 #include "net.h"
 #include "split.h"
 
-#ifdef NO_CURSES
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-#else
-/* Use the curses variant */
-
-#if defined(HAVE_NCURSES_H)
+#ifdef HAVE_NCURSES
+# if defined(HAVE_NCURSES_H)
 #  include <ncurses.h>
-#elif defined(HAVE_NCURSES_CURSES_H)
+# elif defined(HAVE_NCURSES_CURSES_H)
 #  include <ncurses/curses.h>
-#elif defined(HAVE_CURSES_H)
+# elif defined(HAVE_CURSES_H)
 #  include <curses.h>
-#else
+# else
 #  error No curses header file available
-#endif
-
+# endif
+#else
+# include <sys/time.h>
+# include <sys/types.h>
+# include <unistd.h>
 #endif
 
 
@@ -155,7 +152,9 @@ void split_close(void)
 
 int split_keyaction(void) 
 {
-#ifdef NO_CURSES
+#ifdef HAVE_NCURSES
+  char c = getch();
+#else
   fd_set readfds;
   struct timeval tv;
   char c;
@@ -169,8 +168,6 @@ int split_keyaction(void)
     read (0, &c, 1);
   } else 
     return 0;
-#else
-  char c = getch();
 #endif
 
 #if DEBUG


### PR DESCRIPTION
This pull request relates almost entirely to build system.  Change 262291a makes some of the oldest and most broken operating environments not to be able to compile this projec, but I doubt such systems would have worked earlier.

Secondly the pkg-config is made explicitly required. Again some users on some ancient systems may be upset about this, but IMHO the pkg-config, portable and future proved way to find dependencies in uniformed expected manner. And it is not even that controversial anymore - see https://en.wikipedia.org/wiki/GNU_Build_System#Components that has pkg-config listed along side with make, gettext, and gcc.