### PR TITLE
net.c: remove the zero initializer in `nethost`

### DIFF
--- a/net.c
+++ b/net.c
@@ -1495,7 +1495,6 @@ extern void net_reset(struct mtr_ctl *ctl)
   static const struct nethost template = {
     .saved = { -2 },
     .saved_seq_offset = 2 - SAVED_PINGS,
-    .xmit = 0
   };
 
   int at;


### PR DESCRIPTION
(This is relevant to b90a522f23167bd00062504803e94220937aba23, with some discussions on that page)

I think "setting all missing values using value of the last item that was set" is not reasonable.

They will be surely initialized to zero, as what standard says. This behavior has nothing to do with the last item.

[Committee Draft — April 12, 2011 ISO/IEC 9899:201x] (http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1570.pdf)

Page 139 & 140

> ### 6.7.9 Initialization
> ...
> 7\. If a designator has the form
> ```
>  . identifier
> ```
> then the current object (defined below) shall have structure or union type and the
> identifier shall be the name of a member of that type.
> ...
>
> 10\. If an object that has automatic storage duration is not initialized explicitly, its value is
> indeterminate. If an object that has static or thread storage duration is not initialized
> explicitly, then:
> - if it has pointer type, it is initialized to a null pointer;
> - if it has arithmetic type, it is initialized to (positive or unsigned) zero;
> - if it is an aggregate, every member is initialized (recursively) according to these rules,
> and any padding is initialized to zero bits;
> - if it is a union, the first named member is initialized (recursively) according to these
> rules, and any padding is initialized to zero bits;
>
> ...

