### PR TITLE
net: fix net_reopen() initialization

### DIFF
--- a/net.c
+++ b/net.c
@@ -1492,16 +1492,17 @@ extern void net_reopen(struct mtr_ctl *ctl, struct hostent * addr)
 
 extern void net_reset(struct mtr_ctl *ctl)
 {
-  static const struct nethost template = {
-    .saved = { -2 },
-    .saved_seq_offset = 2 - SAVED_PINGS,
-    .xmit = 0
+  static struct nethost template = {
+    .saved_seq_offset = 2 - SAVED_PINGS
   };
 
-  int at;
+  int at, i;
 
   batch_at = ctl->fstTTL - 1;	/* above replacedByMin */
   numhosts = 10;
+
+  for (i = 0; i < SAVED_PINGS; i++)
+    template.saved[i] = -2;
 
   for (at = 0; at < MaxHost; at++) {
     memcpy(&(host[at]), &template, sizeof(template));


### PR DESCRIPTION
Mantas Mikulenas reviewed recent pull reques that contained commit
b90a522f23167bd00062504803e94220937aba23 making a code path quicker.
Unfortunately initialization was incomplete, as demonstrated by R.E.
Wolff in same review.  Fix is to use GCC designated initializer.

Reference: https://github.com/traviscross/mtr/pull/151
Reference: https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html