### PR TITLE
Initialize dns process before opening display

### DIFF
--- a/mtr.c
+++ b/mtr.c
@@ -786,8 +786,8 @@ extern int main(int argc, char **argv)
 
 
     lock(stdout);
-      display_open(&ctl);
       dns_open(&ctl);
+      display_open(&ctl);
 
       display_loop(&ctl);
 


### PR DESCRIPTION
By opening the display before the dns process is forked, the child
inherits things like ncurses's handler for SIGWINCH (window resize
event), which can cause it to crash and leave the parent process in
an infinite select() loop, freezing the display.

This fixes #156.