### PR TITLE
Add displaymode 2 back in

### DIFF
--- a/display.h
+++ b/display.h
@@ -46,6 +46,7 @@ enum {
 enum {
   DisplayModeDefault,
   DisplayModeBlockmap,
+  DisplayModeBlockmapScale,
   DisplayModeMAX	/* this must be the last DisplayMode entry */
 };
 


### PR DESCRIPTION
Issue introduced by 2e4369a61c5bf5a6c221a49350e71f8dfebba539, displaymode 2 was missed when converting from ints to an enum.

This fixes #155.

PS: This kind of breakage is not unexpected considering the ridiculous size of the pull request which introduced it... Looks like those commits should be reviewed more thoroughly.