### PR TITLE
Respect theme foreground color

### DIFF
--- a/gtk.c
+++ b/gtk.c
@@ -495,7 +495,7 @@ static void update_tree_row(struct mtr_ctl *ctl, int row, GtkTreeIter *iter)
     COL_WORST, net_worst(row)/1000,
     COL_STDEV, (float)(net_stdev(row)/1000.0),
     
-    COL_COLOR, net_up(row) ? "black" : "red",
+    COL_COLOR, net_up(row) ? NULL : "red",
 
     -1);
 #ifdef HAVE_IPINFO


### PR DESCRIPTION
This fixes the bug about mtr being almost unusable with dark GTK+ themes. Now non-down rows are colored based on whatever current theme offers instead of `black`.