### PR TITLE
build: use AC_CHECK_LIB for ncurses, rather than pkg-tool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,16 +95,7 @@ AC_ARG_WITH([ncurses],
   [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
   [], [with_ncurses=yes])
 AS_IF([test "x$with_ncurses" = "xyes"],
-  [PKG_CHECK_MODULES([NCURSES], [ncurses], [
-      AC_DEFINE([HAVE_NCURSES], [1], [Define if ncurses library available])
-      AC_CHECK_LIB([ncurses],
-        [use_default_colors],
-        [AC_DEFINE([HAVE_USE_DEFAULT_COLORS], [1],
-          [Define this if your curses library has the use_default_colors() command.]
-        )
-      ])
-    ],
-    [with_ncurses=no])
+  [AC_CHECK_LIB([ncurses], [initscr], [], [with_ncurses=no])
 ])
 AM_CONDITIONAL([WITH_NCURSES], [test "x$with_ncurses" = xyes])
 

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -713,10 +713,8 @@ extern void mtr_curses_open(struct mtr_ctl *ctl)
   raw();
   noecho(); 
   start_color();
-#ifdef HAVE_USE_DEFAULT_COLORS
   if (use_default_colors() == OK)
     bg_col = -1;
-#endif
   for (i = 0; i < NUM_FACTORS; i++)
       init_pair(i+1, i, bg_col);
 

--- a/ui/display.c
+++ b/ui/display.c
@@ -31,7 +31,7 @@
 #include "dns.h"
 #include "asn.h"
 
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
 # include "mtr-curses.h"
 #endif
 
@@ -41,7 +41,7 @@
 
 #include "split.h"
 
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
 # define DEFAULT_DISPLAY DisplayCurses
 #else
 # define DEFAULT_DISPLAY DisplayReport
@@ -85,7 +85,7 @@ extern void display_open(struct mtr_ctl *ctl)
   case DisplayCSV:
     csv_open();
     break;
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   case DisplayCurses:
     mtr_curses_open(ctl);
 # ifdef HAVE_IPINFO
@@ -130,7 +130,7 @@ extern void display_close(struct mtr_ctl *ctl)
   case DisplayCSV:
     csv_close(ctl, now);
     break;
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   case DisplayCurses:
 # ifdef HAVE_IPINFO
     asn_close(ctl);
@@ -154,7 +154,7 @@ extern void display_redraw(struct mtr_ctl *ctl)
 {
   switch(ctl->DisplayMode) {
 
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   case DisplayCurses:
     mtr_curses_redraw(ctl);
     break;
@@ -176,7 +176,7 @@ extern void display_redraw(struct mtr_ctl *ctl)
 extern int display_keyaction(struct mtr_ctl *ctl)
 {
   switch(ctl->DisplayMode) {
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   case DisplayCurses:
     return mtr_curses_keyaction(ctl);
 #endif
@@ -227,7 +227,7 @@ extern void display_loop(struct mtr_ctl *ctl)
 
 extern void display_clear(struct mtr_ctl *ctl)
 {
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   if (ctl->DisplayMode == DisplayCurses)
     mtr_curses_clear(ctl);
 #endif

--- a/ui/display.h
+++ b/ui/display.h
@@ -29,7 +29,7 @@ enum { ActionNone,  ActionQuit,  ActionReset,  ActionDisplay,
 
 enum {
   DisplayReport,
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   DisplayCurses,
 #endif
 #ifdef HAVE_GTK

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -130,7 +130,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
   fputs(" -C, --csv                  output comma separated values\n", out);
   fputs(" -l, --raw                  output raw format\n", out);
   fputs(" -p, --split                split output\n", out);
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   fputs(" -t, --curses               use curses terminal interface\n", out);
 #endif
   fputs("     --displaymode MODE     select initial display mode\n", out);
@@ -296,7 +296,7 @@ static void parse_arg (struct mtr_ctl *ctl, names_t **names, int argc, char **ar
     { "report",         0, NULL, 'r' },
     { "report-wide",    0, NULL, 'w' },
     { "xml",            0, NULL, 'x' },
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
     { "curses",         0, NULL, 't' },
 #endif
 #ifdef HAVE_GTK
@@ -380,7 +380,7 @@ static void parse_arg (struct mtr_ctl *ctl, names_t **names, int argc, char **ar
       ctl->reportwide = 1;
       ctl->DisplayMode = DisplayReport;
       break;
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
     case 't':
       ctl->DisplayMode = DisplayCurses;
       break;

--- a/ui/split.c
+++ b/ui/split.c
@@ -36,7 +36,7 @@
 #include "split.h"
 #include "utils.h"
 
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
 # if defined(HAVE_NCURSES_H)
 #  include <ncurses.h>
 # elif defined(HAVE_NCURSES_CURSES_H)
@@ -149,7 +149,7 @@ extern void split_close(void)
 
 extern int split_keyaction(void) 
 {
-#ifdef HAVE_NCURSES
+#ifdef HAVE_LIBNCURSES
   char c = getch();
 #else
   fd_set readfds;


### PR DESCRIPTION
pkg-tool is indeed an elegant way to check for the presence
of libraries.  When using pkg-config to check for ncurses, this
works great... for Linux.  Unfortunately, on FreeBSD and MacOS,
ncurses is installed by default, but pkg-config is not.  When
pkg-config is installed on these systems, it doesn't know about
the system installed ncurses.

Therefore, somewhat counterintuitively, it is better for portability
to just us AC_CHECK_LIB instead of PKG_CHECK_MODULES to find
ncurses.