### PR TITLE
mtr-packet: Fall back to IPv4 only support if IPv6 sockets fail to open

### DIFF
--- a/packet/probe.h
+++ b/packet/probe.h
@@ -133,6 +133,10 @@ void init_net_state_privileged(
 void init_net_state(
     struct net_state_t *net_state);
 
+bool is_ip_version_supported(
+    struct net_state_t *net_state,
+    int ip_version);
+
 bool is_protocol_supported(
     struct net_state_t *net_state,
     int protocol);

--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -36,16 +36,31 @@ void init_net_state(
     memset(net_state, 0, sizeof(struct net_state_t));
 
     net_state->platform.icmp4 = IcmpCreateFile();
-    if (net_state->platform.icmp4 == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "Failure opening ICMPv4 %d\n", GetLastError());
+    net_state->platform.icmp6 = Icmp6CreateFile();
+
+    if (net_state->platform.icmp4 == INVALID_HANDLE_VALUE
+            && net_state->platform.icmp6 == INVALID_HANDLE_VALUE)
+    {
+        fprintf(stderr, "Failure opening ICMP %d\n", GetLastError());
         exit(EXIT_FAILURE);
+    }
+}
+
+/*
+    If we succeeded at opening the ICMP file handle, we can
+    assume that IP protocol version is supported.
+*/
+bool is_ip_version_supported(
+    struct net_state_t *net_state,
+    int ip_version)
+{
+    if (ip_version == 4) {
+        return (net_state->platform.icmp4 != INVALID_HANDLE_VALUE);
+    } else if (ip_version == 6) {
+        return (net_state->platform.icmp6 != INVALID_HANDLE_VALUE);
     }
 
-    net_state->platform.icmp6 = Icmp6CreateFile();
-    if (net_state->platform.icmp6 == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "Failure opening ICMPv6 %d\n", GetLastError());
-        exit(EXIT_FAILURE);
-    }
+    return false;
 }
 
 /*  On Windows, we only support ICMP probes  */

--- a/packet/probe_unix.h
+++ b/packet/probe_unix.h
@@ -39,6 +39,12 @@ struct probe_platform_t
 /*  We'll use rack sockets to send and recieve probes on Unix systems  */
 struct net_state_platform_t
 {
+    /*  true if we were successful at opening IPv4 sockets  */
+    bool ip4_present;
+
+    /*  true if we were successful at opening IPv6 sockets  */
+    bool ip6_present;
+
     /*  Socket used to send raw IPv4 packets  */
     int ip4_send_socket;
 

--- a/test/probe.py
+++ b/test/probe.py
@@ -316,6 +316,9 @@ class TestProbeUDP(mtrpacket.MtrPacketTest):
     def udp_port_test(self, address):  # type: (unicode) -> None
         'Test UDP probes with variations on source port and dest port'
 
+        if not check_feature(self, 'udp'):
+            return
+
         cmd = '80 send-probe protocol udp ' + address
         self.write_command(cmd)
         reply = self.parse_reply()
@@ -356,6 +359,9 @@ class TestProbeTCP(mtrpacket.MtrPacketTest):
 
         test_basic_probe(self, 4, 'tcp')
 
+        if not check_feature(self, 'tcp'):
+            return
+
         #  Probe a local port assumed to be open  (ssh)
         cmd = '80 send-probe ip-4 127.0.0.1 protocol tcp port 22'
         self.write_command(cmd)
@@ -368,6 +374,9 @@ class TestProbeTCP(mtrpacket.MtrPacketTest):
         'Test IPv6 TCP probes'
 
         test_basic_probe(self, 6, 'tcp')
+
+        if not check_feature(self, 'tcp'):
+            return
 
         #  Probe a local port assumed to be open  (ssh)
         cmd = '80 send-probe ip-6 ::1 protocol tcp port 22'

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -152,6 +152,21 @@ int check_packet_features(
     struct mtr_ctl *ctl,
     struct packet_command_pipe_t *cmdpipe)
 {
+    /*  Check the IP protocol version  */
+    if (ctl->af == AF_INET6) {
+        if (check_feature(ctl, cmdpipe, "ip-6")) {
+            return -1;
+        }
+    } else if (ctl->af == AF_INET) {
+        if (check_feature(ctl, cmdpipe, "ip-4")) {
+            return -1;
+        }
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /*  Check the transport protocol  */
     if (ctl->mtrtype == IPPROTO_ICMP) {
         if (check_feature(ctl, cmdpipe, "icmp")) {
             return -1;


### PR DESCRIPTION
If we fail to open any IPv6 sockets, rather than aborting with an
unrecoverable error, fall back to IPv4 only support.  Socket
creation might fail, for example, when Linux is booted with
the kernel command-line "ipv6.disable=1".

In the case where opening IPv6 sockets fail,
'check-support feature ip-6' will indicate there is no support
for sending IPv6 probes.

Stricter error reporting revealed that test for protocols other
than ICMP were running on Cygwin.  Modified the tests such that
they won't run if the protocol isn't supported.

This fixes the issue reported by @yvs2014 yesterday.