### PR TITLE
Portability fixes - Solaris, NetBSD and OpenBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,7 @@ if WITH_IPINFO
 mtr_SOURCES += ui/asn.c ui/asn.h
 endif
 
-if WITH_NCURSES
+if WITH_CURSES
 mtr_SOURCES += ui/curses.c
 endif
 

--- a/README
+++ b/README
@@ -31,13 +31,16 @@ INSTALLING
 
 	make install
 
-  Note that mtr must be suid-root because it requires access to raw IP 
-  sockets.  See SECURITY for security information.
+  Note that mtr-packet must be suid-root because it requires access to
+  raw IP sockets.  See SECURITY for security information.
 
   Older versions used to require a non-existent path to GTK for a
   correct build of a non-gtk version while GTK was installed. This is
   no longer necessary. ./configure --without-gtk should now work. 
   If it doesn't, try "make WITHOUT_X11=YES" as the make step. 
+
+  On Solaris, you'll need to use GNU make to build.
+  (Use 'gmake' rather than 'make'.)
 
   On Solaris (and possibly other systems) the "gtk" library may be
   installed in a directory where the dynamic linker refuses to look when
@@ -50,12 +53,6 @@ INSTALLING
   and /usr/lib is trusted, and you trust the gtk libs enough to want them
   in a setuid program, then there is something to say for moving them
   to the "trusted" directory.)
-
-  On Solaris, linking usually fails to find "wattr" or something like that.
-  Somehow, I can't seem to be able to automate "configure" finding the right
-  libs on Solaris. So, the solution is that you cut-and-paste the line
-  doing the linking into a terminal window, and add "-lcurses" by hand. 
-  Then it will link. Help on how to catch this in autoconf appreciated.
 
   Building on MacOS should not require any special steps.
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ AC_CHECK_HEADERS([ \
   ncurses/curses.h \
   netinet/in.h \
   socket.h \
+  sys/cdefs.h \
   sys/limits.h \
   sys/socket.h \
   stdio_ext.h \
@@ -95,6 +96,9 @@ AC_ARG_WITH([ncurses],
   [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
   [], [with_ncurses=yes])
 AS_IF([test "x$with_ncurses" = "xyes"],
+
+  # Prefer ncurses over curses, if both are available.
+  # (On Solaris 11.3, ncurses builds and links for us, but curses does not.)
   [AC_SEARCH_LIBS(
     [initscr], [ncurses curses],
     [AC_DEFINE([HAVE_CURSES], [1], [Define if a curses library available])],
@@ -119,12 +123,9 @@ AC_ARG_ENABLE([ipv6],
   [AS_HELP_STRING([--disable-ipv6], [Do not enable IPv6])],
   [WANTS_IPV6=$enableval], [WANTS_IPV6=yes])
 
-USES_IPV6=
-AC_CHECK_FUNC([getaddrinfo], [
-  AS_IF([test "x$WANTS_IPV6" = "xyes"], [
-    AC_DEFINE([ENABLE_IPV6], [1], [Define to enable IPv6])
-    USES_IPV6=yes
-  ])
+AS_IF([test "x$WANTS_IPV6" = "xyes"], [
+  AC_DEFINE([ENABLE_IPV6], [1], [Define to enable IPv6])
+  USES_IPV6=yes
 ])
 
 AC_CHECK_FUNC([socket], [],

--- a/configure.ac
+++ b/configure.ac
@@ -95,9 +95,12 @@ AC_ARG_WITH([ncurses],
   [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
   [], [with_ncurses=yes])
 AS_IF([test "x$with_ncurses" = "xyes"],
-  [AC_CHECK_LIB([ncurses], [initscr], [], [with_ncurses=no])
+  [AC_SEARCH_LIBS(
+    [initscr], [ncurses curses],
+    [AC_DEFINE([HAVE_CURSES], [1], [Define if a curses library available])],
+    [with_ncurses=no])
 ])
-AM_CONDITIONAL([WITH_NCURSES], [test "x$with_ncurses" = xyes])
+AM_CONDITIONAL([WITH_CURSES], [test "x$with_ncurses" = xyes])
 
 AC_CHECK_LIB([cap], [cap_set_proc], [],
   AS_IF([test "$host_os" = linux-gnu],

--- a/packet/cmdparse.c
+++ b/packet/cmdparse.c
@@ -41,7 +41,7 @@ int tokenize_command(
 
     for (i = 0; command_string[i]; i++) {
         if (on_space) {
-            if (!isspace(command_string[i])) {
+            if (!isspace((unsigned char)command_string[i])) {
                 /*  Take care not to exceed the token array length  */
                 if (token_count >= max_tokens) {
                     return -1;
@@ -51,7 +51,7 @@ int tokenize_command(
                 on_space = 0;
             }
         } else {
-            if (isspace(command_string[i])) {
+            if (isspace((unsigned char)command_string[i])) {
                 command_string[i] = 0;
                 on_space = 1;
             }

--- a/packet/command.c
+++ b/packet/command.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "cmdparse.h"
 #include "platform.h"

--- a/packet/deconstruct_unix.c
+++ b/packet/deconstruct_unix.c
@@ -110,13 +110,15 @@ void handle_inner_ip4_packet(
         sizeof(struct IPHeader) + sizeof(struct UDPHeader);
     const int ip_tcp_size =
         sizeof(struct IPHeader) + sizeof(struct TCPHeader);
-    const int ip_sctp_size =
-        sizeof(struct IPHeader) + sizeof(struct SCTPHeader);
     const struct ICMPHeader *icmp;
     const struct UDPHeader *udp;
     const struct TCPHeader *tcp;
-    const struct SCTPHeader *sctp;
     int udp_length;
+#ifdef IPPROTO_SCTP
+    const int ip_sctp_size =
+        sizeof(struct IPHeader) + sizeof(struct SCTPHeader);
+    const struct SCTPHeader *sctp;
+#endif
 
     if (ip->protocol == IPPROTO_ICMP) {
         if (packet_length < ip_icmp_size) {
@@ -185,13 +187,15 @@ void handle_inner_ip6_packet(
         sizeof(struct IP6Header) + sizeof(struct UDPHeader);
     const int ip_tcp_size =
         sizeof(struct IP6Header) + sizeof(struct TCPHeader);
-    const int ip_sctp_size =
-        sizeof(struct IPHeader) + sizeof(struct SCTPHeader);
     const struct ICMPHeader *icmp;
     const struct UDPHeader *udp;
     const struct TCPHeader *tcp;
-    const struct SCTPHeader *sctp;
     int udp_length;
+#ifdef IPPROTO_SCTP
+    const int ip_sctp_size =
+        sizeof(struct IPHeader) + sizeof(struct SCTPHeader);
+    const struct SCTPHeader *sctp;
+#endif
 
     if (ip->protocol == IPPROTO_ICMPV6) {
         if (packet_length < ip_icmp_size) {

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -200,7 +200,8 @@ void format_mpls_string(
     char *append_pos = str;
     const struct mpls_label_t *mpls;
 
-    strcpy(str, "");
+    /*  Start with an empty string  */
+    str[0] = 0;
 
     for (i = 0; i < mpls_count; i++) {
         mpls = &mpls_list[i];

--- a/packet/probe.h
+++ b/packet/probe.h
@@ -23,6 +23,7 @@
 
 #include <netinet/in.h>
 #include <stdbool.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 
 #include "portability/queue.h"

--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -150,9 +150,9 @@ static
 void check_sctp_support(
     struct net_state_t *net_state)
 {
+#ifdef IPPROTO_SCTP
     int sctp_socket;
 
-#ifdef IPPROTO_SCTP
     sctp_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP);
     if (sctp_socket != -1) {
         close(sctp_socket);

--- a/packet/wait_unix.c
+++ b/packet/wait_unix.c
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/select.h>
 
 /*

--- a/portability/queue.h
+++ b/portability/queue.h
@@ -33,7 +33,11 @@
 #ifndef _SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
+#include "config.h"
+
+#ifdef HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
+#endif
 
 /*
  * This file defines four types of data structures: singly-linked lists,

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -225,7 +226,7 @@ void execute_packet_child(void)
         First, try to execute using /usr/bin/env, because this
         will search the PATH for mtr-packet
     */
-    execl("/usr/bin/env", "mtr-packet", mtr_packet_path, NULL);
+    execl("/usr/bin/env", "mtr-packet", mtr_packet_path, (char *)NULL);
 
     /*
         If env fails to execute, try to use the MTR_PACKET environment
@@ -236,7 +237,7 @@ void execute_packet_child(void)
         could be executed.  This will only be the case if /usr/bin/env
         doesn't exist.
     */
-    execl(mtr_packet_path, "mtr-packet", NULL);
+    execl(mtr_packet_path, "mtr-packet", (char *)NULL);
 
     /*  Both exec attempts failed, so nothing to do but exit  */
     exit(1);

--- a/ui/display.c
+++ b/ui/display.c
@@ -31,7 +31,7 @@
 #include "dns.h"
 #include "asn.h"
 
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
 # include "mtr-curses.h"
 #endif
 
@@ -41,7 +41,7 @@
 
 #include "split.h"
 
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
 # define DEFAULT_DISPLAY DisplayCurses
 #else
 # define DEFAULT_DISPLAY DisplayReport
@@ -85,7 +85,7 @@ extern void display_open(struct mtr_ctl *ctl)
   case DisplayCSV:
     csv_open();
     break;
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   case DisplayCurses:
     mtr_curses_open(ctl);
 # ifdef HAVE_IPINFO
@@ -130,7 +130,7 @@ extern void display_close(struct mtr_ctl *ctl)
   case DisplayCSV:
     csv_close(ctl, now);
     break;
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   case DisplayCurses:
 # ifdef HAVE_IPINFO
     asn_close(ctl);
@@ -154,7 +154,7 @@ extern void display_redraw(struct mtr_ctl *ctl)
 {
   switch(ctl->DisplayMode) {
 
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   case DisplayCurses:
     mtr_curses_redraw(ctl);
     break;
@@ -176,7 +176,7 @@ extern void display_redraw(struct mtr_ctl *ctl)
 extern int display_keyaction(struct mtr_ctl *ctl)
 {
   switch(ctl->DisplayMode) {
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   case DisplayCurses:
     return mtr_curses_keyaction(ctl);
 #endif
@@ -227,7 +227,7 @@ extern void display_loop(struct mtr_ctl *ctl)
 
 extern void display_clear(struct mtr_ctl *ctl)
 {
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   if (ctl->DisplayMode == DisplayCurses)
     mtr_curses_clear(ctl);
 #endif

--- a/ui/display.h
+++ b/ui/display.h
@@ -29,7 +29,7 @@ enum { ActionNone,  ActionQuit,  ActionReset,  ActionDisplay,
 
 enum {
   DisplayReport,
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   DisplayCurses,
 #endif
 #ifdef HAVE_GTK

--- a/ui/dns.c
+++ b/ui/dns.c
@@ -179,7 +179,10 @@ extern void dns_open(struct mtr_ctl *ctl)
         rv = getnameinfo  ((struct sockaddr *) &sa, salen, 
 			       hostname, sizeof (hostname), NULL, 0, 0);
         if (rv == 0) {
-          sprintf (result, "%s %s\n", strlongip (ctl, &host), hostname);
+          snprintf (
+            result, sizeof(result),
+            "%s %s\n", strlongip (ctl, &host), hostname);
+
           rv = write (fromdns[1], result, strlen (result));
           if (rv < 0)
             error (0, errno, "write DNS lookup result");

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -44,6 +44,7 @@
 #include <ctype.h>
 #include <assert.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 
@@ -130,7 +131,7 @@ static void __attribute__((__noreturn__)) usage(FILE *out)
   fputs(" -C, --csv                  output comma separated values\n", out);
   fputs(" -l, --raw                  output raw format\n", out);
   fputs(" -p, --split                split output\n", out);
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   fputs(" -t, --curses               use curses terminal interface\n", out);
 #endif
   fputs("     --displaymode MODE     select initial display mode\n", out);
@@ -296,7 +297,7 @@ static void parse_arg (struct mtr_ctl *ctl, names_t **names, int argc, char **ar
     { "report",         0, NULL, 'r' },
     { "report-wide",    0, NULL, 'w' },
     { "xml",            0, NULL, 'x' },
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
     { "curses",         0, NULL, 't' },
 #endif
 #ifdef HAVE_GTK
@@ -380,7 +381,7 @@ static void parse_arg (struct mtr_ctl *ctl, names_t **names, int argc, char **ar
       ctl->reportwide = 1;
       ctl->DisplayMode = DisplayReport;
       break;
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
     case 't':
       ctl->DisplayMode = DisplayCurses;
       break;

--- a/ui/split.c
+++ b/ui/split.c
@@ -36,7 +36,7 @@
 #include "split.h"
 #include "utils.h"
 
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
 # if defined(HAVE_NCURSES_H)
 #  include <ncurses.h>
 # elif defined(HAVE_NCURSES_CURSES_H)
@@ -149,7 +149,7 @@ extern void split_close(void)
 
 extern int split_keyaction(void) 
 {
-#ifdef HAVE_LIBNCURSES
+#ifdef HAVE_CURSES
   char c = getch();
 #else
   fd_set readfds;

--- a/ui/split.c
+++ b/ui/split.c
@@ -106,7 +106,7 @@ extern void split_redraw(struct mtr_ctl *ctl)
                net_best(at) /1000, net_avg(at)/1000,
                net_worst(at)/1000);
     } else {
-      sprintf(newLine, "???");
+      snprintf(newLine, sizeof(newLine), "???");
     }
 
     if (strcmp(newLine, Lines[at]) == 0) {
@@ -150,7 +150,7 @@ extern void split_close(void)
 extern int split_keyaction(void) 
 {
 #ifdef HAVE_CURSES
-  char c = getch();
+  unsigned char c = getch();
 #else
   fd_set readfds;
   struct timeval tv;

--- a/ui/utils.c
+++ b/ui/utils.c
@@ -46,7 +46,7 @@ extern char *trim(char *str, const char c)
   size_t len;
 
   /* left trim */
-  while (*p && (isspace(*p) || (c && *p == c)))
+  while (*p && (isspace((unsigned char)*p) || (c && *p == c)))
     p++;
   if (str < p) {
     len = strlen(str);
@@ -57,7 +57,7 @@ extern char *trim(char *str, const char c)
   len = strlen(str);
   while (len) {
     len--;
-    if (isspace(str[len]) || (c && str[len] == c)) {
+    if (isspace((unsigned char)str[len]) || (c && str[len] == c)) {
       continue;
     }
     len++;


### PR DESCRIPTION
Included are fixes to building and running on Solaris, NetBSD and OpenBSD.  Some are related to linking with curses / ncurses, and some are related to new mtr-packet code.

I have tested that, as of this change, mtr builds, links with ncurses or curses without hassle, and functions on each of:

Cygwin 2.6.0 on Windows 10
Debian 8.6.0  ("Jessie")
Fedora 25
FreeBSD 11.0
MacOS 10.12.2  ("MacOS Sierra")
NetBSD 7.0.2
OpenBSD 6.0
Raspbian 8  ("Jessie" on armv6l)
Solaris 11.3
Ubuntu 16.10
