### PR TITLE
Remove unnecessary MTR_PACKET env variable.

### DIFF
--- a/build-aux/mtr.bat
+++ b/build-aux/mtr.bat
@@ -18,15 +18,15 @@ rem  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 rem
 
 rem Assume the path of this batch file is the mtr installation location
-set MTR_DIR=%~dp0
+set "MTR_DIR=%~dp0"
 
-set MTR_BIN=%MTR_DIR%\bin
+set "MTR_BIN=%MTR_DIR%\bin"
 
 rem ncurses needs to locate the cygwin terminfo file
-set TERMINFO=%MTR_DIR%\terminfo
+set "TERMINFO=%MTR_DIR%\terminfo"
 
 rem mtr needs to know the location to the packet generator
-set MTR_PACKET=%MTR_BIN%\mtr-packet.exe
+set "MTR_PACKET=%MTR_BIN%\mtr-packet.exe"
 
 rem Pass along commandline arguments
-%MTR_BIN%\mtr %*
+"%MTR_BIN%\mtr" %*

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -210,34 +210,26 @@ int check_packet_features(
 static
 void execute_packet_child(void)
 {
-    char *mtr_packet_path;
-
     /*
-        Allow the MTR_PACKET environment variable to overrride
+        Allow the MTR_PACKET environment variable to override
         the path to the mtr-packet executable.  This is necessary
         for debugging changes for mtr-packet.
     */
-    mtr_packet_path = getenv("MTR_PACKET");
+    char *mtr_packet_path = getenv("MTR_PACKET");
     if (mtr_packet_path == NULL) {
         mtr_packet_path = "mtr-packet";
     }
 
     /*
-        First, try to execute using /usr/bin/env, because this
-        will search the PATH for mtr-packet
+        First, try to execute mtr-packet from PATH
+        or MTR_PACKET environment variable.
     */
-    execl("/usr/bin/env", "mtr-packet", mtr_packet_path, (char *)NULL);
+    execlp(mtr_packet_path, "mtr-packet", (char *)NULL);
 
     /*
-        If env fails to execute, try to use the MTR_PACKET environment
-        as a full path to the executable.  This is necessary because on
-        Windows, minimal mtr binary distributions will lack /usr/bin/env.
-
-        Note: A side effect is that an mtr-packet in the current directory
-        could be executed.  This will only be the case if /usr/bin/env
-        doesn't exist.
+        If mtr-packet is not found, try to use mtr-packet from current directory
     */
-    execl(mtr_packet_path, "mtr-packet", (char *)NULL);
+    execl("./mtr-packet", "./mtr-packet", (char *)NULL);
 
     /*  Both exec attempts failed, so nothing to do but exit  */
     exit(1);


### PR DESCRIPTION
It is not nice to execute program based on some env variable. Also the
workaround for (non)issue make it harder to work with mtr without
installing in my opinion.

First we try mtr-packet from PATH. In case it is not found we try binary
from current directory. This way user can easily overwrite selected
binary by modifying PATH env variable. But we don't require having
either mtr or mtr-packet in PATH.

Also fix batch file to support paths with spaces on Windows.

------------------------------------

I'm open for discussion, but I find current design little bit clunky.