### PR TITLE
Add missing errno.h include.

### DIFF
--- a/packet/command_cygwin.c
+++ b/packet/command_cygwin.c
@@ -18,6 +18,7 @@
 
 #include "command.h"
 
+#include <errno.h>
 #include <io.h>
 #include <stdio.h>
 

--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -18,6 +18,7 @@
 
 #include "probe.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <winternl.h>
 


### PR DESCRIPTION
This fixes compilation with Clang on Cygwin.