### PR TITLE
Report "no route to host" in curses UI when a probe response arrives with an ICMP destination unreachable code

### DIFF
--- a/packet/deconstruct_unix.c
+++ b/packet/deconstruct_unix.c
@@ -394,6 +394,15 @@ void handle_received_icmp4_packet(
             handle_inner_ip4_packet(net_state, remote_addr,
                                     ICMP_ECHOREPLY, inner_ip, inner_size,
                                     timestamp, mpls_count, mpls);
+        } else {
+            /*
+                ICMP_DEST_UNREACH subtypes other than port unreachable
+                indicate an exceptional condition, and will be reported
+                as a "no route to host" probe response.
+            */
+            handle_inner_ip4_packet(net_state, remote_addr,
+                                    ICMP_DEST_UNREACH, inner_ip, inner_size,
+                                    timestamp, mpls_count, mpls);
         }
     }
 }
@@ -442,6 +451,10 @@ void handle_received_icmp6_packet(
         if (icmp->code == ICMP6_PORT_UNREACH) {
             handle_inner_ip6_packet(net_state, remote_addr,
                                     ICMP_ECHOREPLY, inner_ip, inner_size,
+                                    timestamp, mpls_count, mpls);
+        } else {
+            handle_inner_ip6_packet(net_state, remote_addr,
+                                    ICMP_DEST_UNREACH, inner_ip, inner_size,
                                     timestamp, mpls_count, mpls);
         }
     }

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -248,6 +248,8 @@ void respond_to_probe(
 
     if (icmp_type == ICMP_TIME_EXCEEDED) {
         result = "ttl-expired";
+    } else if (icmp_type == ICMP_DEST_UNREACH) {
+        result = "no-route";
     } else {
         assert(icmp_type == ICMP_ECHOREPLY);
         result = "reply";

--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -102,14 +102,6 @@ void report_win_error(
     /*  It could be that we got no reply because of timeout  */
     if (err == IP_REQ_TIMED_OUT || err == IP_SOURCE_QUENCH) {
         printf("%d no-reply\n", command_token);
-    } else if (err == IP_DEST_HOST_UNREACHABLE
-               || err == IP_DEST_PORT_UNREACHABLE
-               || err == IP_DEST_PROT_UNREACHABLE
-               || err == IP_DEST_NET_UNREACHABLE
-               || err == IP_DEST_UNREACHABLE
-               || err == IP_DEST_NO_ROUTE
-               || err == IP_BAD_ROUTE || err == IP_BAD_DESTINATION) {
-        printf("%d no-route\n", command_token);
     } else if (err == ERROR_INVALID_NETNAME) {
         printf("%d address-not-available\n", command_token);
     } else if (err == ERROR_INVALID_PARAMETER) {
@@ -186,7 +178,18 @@ void WINAPI on_icmp_reply(
         icmp_type = ICMP_ECHOREPLY;
     } else if (reply_status == IP_TTL_EXPIRED_TRANSIT
                || reply_status == IP_TTL_EXPIRED_REASSEM) {
+
         icmp_type = ICMP_TIME_EXCEEDED;
+    } else if (reply_status == IP_DEST_HOST_UNREACHABLE
+               || reply_status == IP_DEST_PORT_UNREACHABLE
+               || reply_status == IP_DEST_PROT_UNREACHABLE
+               || reply_status == IP_DEST_NET_UNREACHABLE
+               || reply_status == IP_DEST_UNREACHABLE
+               || reply_status == IP_DEST_NO_ROUTE
+               || reply_status == IP_BAD_ROUTE
+               || reply_status == IP_BAD_DESTINATION) {
+
+        icmp_type = ICMP_DEST_UNREACH;
     }
 
     if (icmp_type != -1) {

--- a/ui/cmdpipe.h
+++ b/ui/cmdpipe.h
@@ -47,6 +47,7 @@ void (
     *probe_reply_func_t) (
     struct mtr_ctl * ctl,
     int sequence,
+    int err,
     struct mplslen * mpls,
     ip_t * addr,
     int round_trip_time);

--- a/ui/display.c
+++ b/ui/display.c
@@ -18,8 +18,10 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <time.h>
 
@@ -249,4 +251,27 @@ void display_clear(
     if (ctl->DisplayMode == DisplayCurses)
         mtr_curses_clear(ctl);
 #endif
+}
+
+
+/*
+    Given an errno error code corresponding to a host entry, return a
+    user readable error string.
+*/
+char *host_error_to_string(
+    int err)
+{
+    if (err == ENETUNREACH) {
+        return "no route to host";
+    }
+
+    if (err == ENETDOWN) {
+        return "network down";
+    }
+
+    if (err == 0) {
+        return "waiting for reply";
+    }
+
+    return strerror(err);
 }

--- a/ui/display.h
+++ b/ui/display.h
@@ -81,3 +81,5 @@ extern void display_loop(
     struct mtr_ctl *ctl);
 extern void display_clear(
     struct mtr_ctl *ctl);
+extern char *host_error_to_string(
+    int err);

--- a/ui/net.h
+++ b/ui/net.h
@@ -56,6 +56,8 @@ extern int net_last(
     int at);
 extern ip_t *net_addr(
     int at);
+extern int net_err(
+    int at);
 extern void *net_mpls(
     int at);
 extern void *net_mplss(


### PR DESCRIPTION
When a host is reported as unreachable in response to a particular network probe, the Windows version of the mtr UI had the unfortuante behavior of exiting and and printing a terse message.  This is surprising to a user, who would expect mtr probes and reporting to continue.

With this change, probing continues and a status reading "no route to host" is displayed in the probe report.

This change will also improve the reporting of the Unix version of mtr, now specifying "no route to host" instead of misleadingly indicating that no reply has been received.

This fixes issue #179.