### PR TITLE
json: Fix malformed json when the "hubs" list is empty

### DIFF
--- a/ui/report.c
+++ b/ui/report.c
@@ -364,11 +364,12 @@ void json_close(
             }
         }
         if (at + 1 == max) {
-            printf("    }]\n");
+            printf("    }");
         } else {
             printf("    },\n");
         }
     }
+    printf("]\n");
     printf("  }\n");
     printf("}\n");
 }


### PR DESCRIPTION
When generating JSON output, and when no hosts are found when
probing, the generated JSON was malformed.  (i.e. when the "hubs" list
in the generated JSON is empty, there was no closing bracket.)  This can
be reproduced by tracing to an unused host address on the local subnet.

This fixues issue #190.