### PR TITLE
commandline: Added --interface for using a named network interface

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -77,6 +77,9 @@ mtr \- a network diagnostic tool
 .B \-\-mpls\c
 ]
 [\c
+.BI \-I \ NAME\c
+]
+[\c
 .BI \-a \ ADDRESS\c
 ]
 [\c
@@ -376,6 +379,12 @@ Use this option to tell
 .B mtr 
 to display information from ICMP extensions for MPLS (RFC 4950)
 that are encoded in the response packets.
+.TP
+.B \-I \fINAME\fR, \fB\-\-interface \fINAME
+Use the network interface with a specific name for sending network probes.
+This can be useful when you have multiple network interfaces with routes
+to your destination, for example both wired Ethernet and WiFi, and wish
+to test a particular interface.
 .TP
 .B \-a \fIADDRESS\fR, \fB\-\-address \fIADDRESS
 Use this option to bind the outgoing socket to

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -83,6 +83,7 @@ struct mtr_ctl {
     float WaitTime;
     float GraceTime;
     char *Hostname;
+    char *InterfaceName;
     char *InterfaceAddress;
     char LocalHostname[128];
     int ipinfo_no;


### PR DESCRIPTION
Using '--interface' on the commandline (or '-I') will specify
a network interface by name.  This is sometimes a more convenient
alternative to using '--address' for specifying a source address
from which to send probes.

This can be useful when you have both a wired ethernet connection
and WiFi connection, and wish to use a specific connection for the
purposes of tracing.

This feature was requested in issue #207.

This change also cleans up main() slightly by factoring out the
hostent structure generation.