### PR TITLE
mtr-packet: use ICMP and UDP without privilege on linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AC_CHECK_HEADERS([ \
   error.h \
   fcntl.h \
   linux/icmp.h \
+  linux/errqueue.h \
   ncurses.h \
   ncurses/curses.h \
   netinet/in.h \

--- a/packet/command.c
+++ b/packet/command.c
@@ -321,6 +321,7 @@ void send_probe_command(
     param.ttl = 255;
     param.packet_size = 64;
     param.timeout = 10;
+    param.is_probing_byte_order = false;
 
     for (i = 0; i < command->argument_count; i++) {
         name = command->argument_name[i];

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -26,6 +26,11 @@
 
 #include "protocols.h"
 
+/* For Mac OS X and FreeBSD */
+#ifndef SOL_IP
+#define SOL_IP IPPROTO_IP
+#endif
+
 /*  A source of data for computing a checksum  */
 struct checksum_source_t {
     const void *data;

--- a/packet/deconstruct_unix.h
+++ b/packet/deconstruct_unix.h
@@ -43,4 +43,13 @@ void handle_received_ip6_packet(
     int packet_length,
     struct timeval *timestamp);
 
+void handle_error_queue_packet(
+    struct net_state_t *net_state,
+    const struct sockaddr_storage *remote_addr,
+    int icmp_result,
+    int proto,
+    char *packet,
+    int packet_length,
+    struct timeval *timestamp);
+
 #endif

--- a/packet/probe.h
+++ b/packet/probe.h
@@ -79,6 +79,9 @@ struct probe_param_t {
 
     /*  The number of seconds to wait before assuming the probe was lost  */
     int timeout;
+
+    /*  true is the probe is to test byte order */
+    bool is_probing_byte_order;
 };
 
 /*  Tracking information for an outstanding probe  */
@@ -170,6 +173,7 @@ int decode_address_string(
     struct sockaddr_storage *address);
 
 int resolve_probe_addresses(
+    struct net_state_t *net_state,
     const struct probe_param_t *param,
     struct sockaddr_storage *dest_sockaddr,
     struct sockaddr_storage *src_sockaddr);

--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -329,7 +329,8 @@ void send_probe(
     char payload[PACKET_BUFFER_SIZE];
     int payload_size;
 
-    if (resolve_probe_addresses(param, &dest_sockaddr, &src_sockaddr)) {
+    if (resolve_probe_addresses(net_state, param, &dest_sockaddr,
+                &src_sockaddr)) {
         printf("%d invalid-argument\n", param->command_token);
         return;
     }

--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -44,6 +44,8 @@ void init_net_state(
         fprintf(stderr, "Failure opening ICMP %d\n", GetLastError());
         exit(EXIT_FAILURE);
     }
+    net_state->platform.ip4_socket_raw = false;
+    net_state->platform.ip6_socket_raw = false;
 }
 
 /*

--- a/packet/probe_cygwin.h
+++ b/packet/probe_cygwin.h
@@ -69,6 +69,8 @@ struct probe_platform_t {
 struct net_state_platform_t {
     HANDLE icmp4;
     HANDLE icmp6;
+    bool ip4_socket_raw;
+    bool ip6_socket_raw;
 };
 
 #endif

--- a/packet/probe_unix.h
+++ b/packet/probe_unix.h
@@ -43,11 +43,26 @@ struct net_state_platform_t {
     /*  true if we were successful at opening IPv6 sockets  */
     bool ip6_present;
 
+    /* true if ipv4 socket is raw socket */
+    bool ip4_socket_raw;
+
+    /* true if ipv6 socket is raw socket */
+    bool ip6_socket_raw;
+
     /*  Socket used to send raw IPv4 packets  */
     int ip4_send_socket;
 
     /*  Socket used to receive IPv4 ICMP replies  */
     int ip4_recv_socket;
+
+    /*  Socket used to probe byte order */
+    int ip4_tmp_icmp_socket;
+
+    /*  Socket used to tx & rx non-raw IPv4 icmp packets */
+    int ip4_txrx_icmp_socket;
+
+    /*  Socket used to send IPv4 udp packets and receive icmp err packets */
+    int ip4_txrx_udp_socket;
 
     /*  Send socket for ICMPv6 packets  */
     int icmp6_send_socket;
@@ -57,6 +72,12 @@ struct net_state_platform_t {
 
     /*  Receive socket for IPv6 packets  */
     int ip6_recv_socket;
+
+    /*  Socket used to tx & rx non-raw IPv6 icmp packets */
+    int ip6_txrx_icmp_socket;
+
+    /*  Socket used to send IPv6 udp packets and receive icmp err packets */
+    int ip6_txrx_udp_socket;
 
     /*
        true if we should encode the IP header length in host order.

--- a/packet/wait_unix.c
+++ b/packet/wait_unix.c
@@ -39,8 +39,8 @@ int gather_read_fds(
 {
     int nfds;
     int probe_nfds;
-    int ip4_socket = net_state->platform.ip4_recv_socket;
-    int ip6_socket = net_state->platform.ip6_recv_socket;
+    int ip4_socket;
+    int ip6_socket;
     int command_stream = command_buffer->command_stream;
 
     FD_ZERO(read_set);
@@ -49,14 +49,42 @@ int gather_read_fds(
     FD_SET(command_stream, read_set);
     nfds = command_stream + 1;
 
-    FD_SET(ip4_socket, read_set);
-    if (ip4_socket >= nfds) {
-        nfds = ip4_socket + 1;
+    if (net_state->platform.ip4_socket_raw) {
+        ip4_socket = net_state->platform.ip4_recv_socket;
+        FD_SET(ip4_socket, read_set);
+        if (ip4_socket >= nfds) {
+            nfds = ip4_socket + 1;
+        }
+    } else {
+        ip4_socket = net_state->platform.ip4_txrx_icmp_socket;
+        FD_SET(ip4_socket, read_set);
+        if (ip4_socket >= nfds) {
+            nfds = ip4_socket + 1;
+        }
+        ip4_socket = net_state->platform.ip4_txrx_udp_socket;
+        FD_SET(ip4_socket, read_set);
+        if (ip4_socket >= nfds) {
+            nfds = ip4_socket + 1;
+        }
     }
 
-    FD_SET(ip6_socket, read_set);
-    if (ip6_socket >= nfds) {
-        nfds = ip6_socket + 1;
+    if (net_state->platform.ip6_socket_raw) {
+        ip6_socket = net_state->platform.ip6_recv_socket;
+        FD_SET(ip6_socket, read_set);
+        if (ip6_socket >= nfds) {
+            nfds = ip6_socket + 1;
+        }
+    } else {
+        ip6_socket = net_state->platform.ip6_txrx_icmp_socket;
+        FD_SET(ip6_socket, read_set);
+        if (ip6_socket >= nfds) {
+            nfds = ip6_socket + 1;
+        }
+        ip6_socket = net_state->platform.ip6_txrx_udp_socket;
+        FD_SET(ip6_socket, read_set);
+        if (ip6_socket >= nfds) {
+            nfds = ip6_socket + 1;
+        }
     }
 
     probe_nfds = gather_probe_sockets(net_state, write_set);


### PR DESCRIPTION
This commit enables non-privileged users to use mtr on linux without
setuid. Currently ICMP and UDP protocols are supported in this commit.
Previously, to use mtr on linux with protocol ICMP and UDP, RAW sockets
have to be opened to send out packets and receive ICMP errors, so users
must have RAW socket permission to use this program. The goal of this
commit is to make mtr usable for normal users without RAW socket
permission. A sysctl might need to be set to make this work,
https://lkml.org/lkml/2011/5/18/305
The changes include:
(1) The origianl logic is not changed, but instead, when the program
fails to open RAW sockets, it will fallback to opening DGRAM scoekts.
(2) A new flag is created to indicate whether RAW socket is used for
IPv4 and IPv6 respectively.
(3) When using DGRAM sockets to send out packets, receive sockets are
not required. Instead, IP_RECVERR is enabled to receive ICMP errors.
(4) Packet receiving function is changed from recvfrom() to recvmsg() to
retrieve more information.
(5) When error is indicated, the program will check the error type and
read from the error queue of the socket. Original payload causing the
error will be read out from the error queue to match for probe, and
additional data (e.g. source ip of ICMP error packets) will be retrieved
from CMSG.
(6) Use a separate socket to probe byter order if raw socket creation
fails, to avoid double bind issue.
(7) Also a few tweaks are added to make non-RAW socket working.
