### PR TITLE
add Cygwin build conditional to skip UID 0 checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,9 @@ before running ./bootstrap.sh again.])
 PKG_PROG_PKG_CONFIG
 
 AM_CONDITIONAL([CYGWIN], [test "$host_os" = cygwin])
+AM_COND_IF([CYGWIN],
+           [AC_DEFINE([USING_CYGWIN], [1], [Building Under Cygwin.])],
+           [])
 
 # Check bytes in types.
 AC_CHECK_SIZEOF([unsigned char], [1])

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -235,8 +235,10 @@ int mtr_curses_keyaction(
 
         if (f <= 0.0)
             return ActionNone;
+#ifndef USING_CYGWIN
         if (getuid() != 0 && f < 1.0)
             return ActionNone;
+#endif
         ctl->WaitTime = f;
 
         return ActionNone;

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -294,8 +294,12 @@ static void Toolbar_fill(
 
     /* allow root only to set zero delay */
     Adjustment = (GtkAdjustment *) gtk_adjustment_new(ctl->WaitTime,
+#ifndef USING_CYGWIN
                                                       getuid() ==
                                                       0 ? 0.01 : 1.00,
+#else
+                                                      0.01,
+#endif
                                                       999.99, 1.0, 10.0,
                                                       0.0);
     Button = gtk_spin_button_new(Adjustment, 0.5, 2);

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -484,10 +484,12 @@ static void parse_arg(
             if (ctl->WaitTime <= 0.0) {
                 error(EXIT_FAILURE, 0, "wait time must be positive");
             }
+#ifndef USING_CYGWIN
             if (getuid() != 0 && ctl->WaitTime < 1.0) {
                 error(EXIT_FAILURE, 0,
                       "non-root users cannot request an interval < 1.0 seconds");
             }
+#endif
             break;
         case 'f':
             ctl->fstTTL =


### PR DESCRIPTION
Uses the C preprocessor to skip code that performs checks against UID 0 using `getuid()` when building under Cygwin.

Tested working against Cygwin x86_64 (no UID 0 checks are performed) and macOS Sierra (macports toolchain, UID 0 checks are performed).

GTK is untested, but should work.