### PR TITLE
mtr-packet: fix a bug causing IPv6 raw socket not working

### DIFF
--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -458,7 +458,7 @@ void init_net_state(
         set_socket_nonblocking(net_state->platform.ip4_txrx_icmp_socket);
         set_socket_nonblocking(net_state->platform.ip4_txrx_udp_socket);
     }
-    if (net_state->platform.ip4_socket_raw) {
+    if (net_state->platform.ip6_socket_raw) {
         set_socket_nonblocking(net_state->platform.ip6_recv_socket);
     } else {
         set_socket_nonblocking(net_state->platform.ip6_txrx_icmp_socket);


### PR DESCRIPTION
This bug causes mtr not working on IPv6 only machines if invoked by root
user, and it is fixed in this commit.