### PR TITLE
Update mtr.h

### DIFF
--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -133,7 +133,7 @@ extern const struct fields data_fields[MAXFLD];
 /* MPLS label object */
 struct mplslen {
     unsigned long label[MAXLABELS];     /* label value */
-    uint8_t exp[MAXLABELS];     /* experimental bits */
+    uint8_t tc[MAXLABELS];     /* Traffic Class bits */
     uint8_t ttl[MAXLABELS];     /* MPLS TTL */
     char s[MAXLABELS];          /* bottom of stack */
     char labels;                /* how many labels did we get? */


### PR DESCRIPTION
RFC 5462 - MPLS EXP Field renamed to TC Field (Traffic Class)