### PR TITLE
Option --ipinfo 1 can not work properly

### DIFF
--- a/ui/asn.c
+++ b/ui/asn.c
@@ -307,7 +307,7 @@ char *fmt_ipinfo(
 int is_printii(
     struct mtr_ctl *ctl)
 {
-    return ((ctl->ipinfo_no >= 0) && (ctl->ipinfo_no != ctl->ipinfo_max));
+    return (ctl->ipinfo_no >= 0);
 }
 
 void asn_open(


### PR DESCRIPTION
### Command
```
	sudo ./mtr -y 1 baidu.com
```


### Before modification
```
 Host                                                          Loss%   Snt   Last   Avg  Best  Wrst StDev
 1. bogon                                                       0.0%    10    2.0   2.6   2.0   3.9   0.7
 2. 1.80.202.1.static.bjtelecom.net                             0.0%    10    3.3   5.0   3.3  11.2   2.3
 3. bj141-158-73.bjtelecom.net                                  0.0%    10    3.0   3.9   2.6   6.0   1.4
 4. 220.181.0.54                                               66.7%    10    4.2   4.5   4.2   4.9   0.4
 5. (waiting for reply)
 6. 220.181.17.94                                               0.0%     9    5.7   4.5   3.2   7.7   1.4
 7. (waiting for reply)
 8. 220.181.57.216                                              0.0%     9    4.4   5.2   3.5   9.9   2.2
```
 
 
 
### After modification
```
  Host                                                          Loss%   Snt   Last   Avg  Best  Wrst StDev
 1. ???                bogon                                    0.0%     6    2.1   2.8   2.1   3.7   0.7
 2. 1.202.0.0/17       1.80.202.1.static.bjtelecom.net          0.0%     6    4.2   4.5   4.2   4.8   0.2
 3. 219.141.128.0/17   bj141-158-73.bjtelecom.net               0.0%     6    3.5   3.5   2.8   4.3   0.6
 4. 220.181.0.0/19     220.181.0.54                            33.3%     6    5.2   4.3   3.5   5.2   0.7
 5. (waiting for reply)
 6. 220.181.0.0/19     220.181.17.94                            0.0%     5    4.1   4.1   3.3   5.9   1.0
 7. (waiting for reply)
 8. 220.181.32.0/19    220.181.57.216                           0.0%     5    3.2   4.4   3.2   6.9   1.5
```