### PR TITLE
Modify the access method for ipinfo

### DIFF
--- a/ui/asn.h
+++ b/ui/asn.h
@@ -31,3 +31,7 @@ extern ATTRIBUTE_CONST int get_iiwidth(
     int ipinfo_no);
 extern int is_printii(
     struct mtr_ctl *ctl);
+extern int res_waitfd(
+    void);
+extern void res_ack(
+    struct mtr_ctl *ctl);


### PR DESCRIPTION
Use child process to get the ipinfo and pass it to parent process, using the -lresolv library.