### PR TITLE
Masking entries on the IPs/Hostnames list (curses interface)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ confinc
 confmf
 conftest.*
 stamp-h1*
+tags
+cscope.out
 
 /build-aux/compile
 /build-aux/depcomp

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -279,6 +279,25 @@ int mtr_curses_keyaction(
         ctl->maxTTL = i;
 
         return ActionNone;
+    case '0':
+        mvprintw(2, 0, "Mask : %d\n\n", ctl->fstMASK);
+        move(2, 7);
+        refresh();
+        while ((c = getch()) != '\n' && i < MAXFLD) {
+            attron(A_BOLD);
+            printw("%c", c);
+            attroff(A_BOLD);
+            refresh();
+            buf[i++] = c;       /* need more checking on 'c' */
+        }
+        buf[i] = '\0';
+        i = atoi(buf);
+
+        if (i > (MaxHost - 1))
+            return ActionNone;
+        ctl->fstMASK = i;
+
+        return ActionNone;
         /* fields to display & their ordering */
     case 'o':
         mvprintw(2, 0, "Fields: %s\n\n", ctl->fld_active);
@@ -434,13 +453,17 @@ static void mtr_curses_hosts(
             if (is_printii(ctl))
                 printw(fmt_ipinfo(ctl, addr));
 #endif
-            if (name != NULL) {
-                if (ctl->show_ips)
-                    printw("%s (%s)", name, strlongip(ctl, addr));
-                else
-                    printw("%s", name);
+            if ( at < ctl->fstMASK ) {
+                printw("___ip_masked___");
             } else {
-                printw("%s", strlongip(ctl, addr));
+                if (name != NULL) {
+                    if (ctl->show_ips)
+                        printw("%s (%s)", name, strlongip(ctl, addr));
+                    else
+                        printw("%s", name);
+                } else {
+                    printw("%s", strlongip(ctl, addr));
+                }
             }
             attroff(A_BOLD);
 
@@ -655,7 +678,11 @@ static void mtr_curses_graph(
                 printw(fmt_ipinfo(ctl, addr));
 #endif
             name = dns_lookup(ctl, addr);
-            printw("%s", name ? name : strlongip(ctl, addr));
+            if ( at < ctl->fstMASK ) {
+                printw("___ip_masked___");
+            } else {
+                printw("%s", name ? name : strlongip(ctl, addr));
+            }
         } else {
             attron(A_BOLD);
             printw("(%s)", host_error_to_string(err));
@@ -700,7 +727,11 @@ void mtr_curses_redraw(
     pwcenter(buf);
     attroff(A_BOLD);
 
-    mvprintw(1, 0, "%s (%s)", ctl->LocalHostname, net_localaddr());
+    if (ctl->fstMASK == 0) {
+        mvprintw(1, 0, "%s (%s)", ctl->LocalHostname, net_localaddr());
+    } else {
+        mvprintw(1, 0, "hostname masked (ip addr masked)", ctl->LocalHostname, net_localaddr());
+    }
     t = time(NULL);
     mvprintw(1, maxx - 25, iso_time(&t));
     printw("\n");

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -387,6 +387,8 @@ int mtr_curses_keyaction(
         printw("  y       switching IP info\n");
         printw("  z       toggle ASN info on/off\n");
 #endif
+        printw
+            ("  0 <n>   masks first #n IPs in the TTL list (0 = masking off)\n");
         printw("\n");
         printw(" press any key to go back...");
         getch();                /* read and ignore 'any key' */
@@ -730,7 +732,7 @@ void mtr_curses_redraw(
     if (ctl->fstMASK == 0) {
         mvprintw(1, 0, "%s (%s)", ctl->LocalHostname, net_localaddr());
     } else {
-        mvprintw(1, 0, "hostname masked (ip addr masked)", ctl->LocalHostname, net_localaddr());
+        mvprintw(1, 0, "hostname masked (ip masked)", ctl->LocalHostname, net_localaddr());
     }
     t = time(NULL);
     mvprintw(1, maxx - 25, iso_time(&t));

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -114,6 +114,7 @@ struct mtr_ctl {
         use_dns:1,
         show_ips:1,
         enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5;
+    int fstMASK                 /* first whitout masking IP address */
 };
 
 /* dynamic field drawing */

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -114,7 +114,7 @@ struct mtr_ctl {
         use_dns:1,
         show_ips:1,
         enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5;
-    int fstMASK                 /* first whitout masking IP address */
+    int fstMASK                 /* initial hub(ttl) without masking IP address/DNS name */
 };
 
 /* dynamic field drawing */

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -114,7 +114,7 @@ struct mtr_ctl {
         use_dns:1,
         show_ips:1,
         enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5;
-    int fstMASK                 /* initial hub(ttl) without masking IP address/DNS name */
+    int fstMASK;                 /* initial hub(ttl) without masking IP address/DNS name */
 };
 
 /* dynamic field drawing */


### PR DESCRIPTION
Hi,
Recently I needed a functionality, to mask initial part of the ip addresses/hostnames from the traceroute information, to hide local part of the network route and get something similar to this output, showing the result of the command:

` $ mtr --tcp -P 80 --curses github.com`

The output is:

```                             My traceroute  [v0.92.69-ff32]
hostname masked (ip masked)                                    2018-09-23T20:20:28+0200
Keys:  Help   Display mode   Restart statistics   Order of fields   quit

                             Last  58 pings
 1. ___ip_masked___                                                ....................
 2. ___ip_masked___                                                ....................
 3. ___ip_masked___                                                ....................
 4. ___ip_masked___                                                ....................
 5. ___ip_masked___                                                ....................
 6. ___ip_masked___                                                ....................
 7. pzn-b1-link.telia.net                                          .....1...1.......1.1
 8. hbg-bb4-link.telia.net                                         .1.......1.1........
 9. ldn-bb4-link.telia.net                                         11..11...1...111.11.
10. ash-bb4-link.telia.net                                         ............1.1.....
11. rest-b1-link.telia.net                                         ....................
12. github-ic-325491-ash-b1.                                       11.....111.....11..?
13. github-ic-325490-ash-b1.                                       ??1?.?>?1>??1..1???
14. (waiting for reply)                                            ???????????????????
15. lb-192-30-253-113-iad.gi                                       .111>1111>1?1???111

Scale:  .:117 ms  1:461 ms  2:1034 ms  3:1837 ms  a:2869 ms  b:4130 ms  c:5621 ms  >
```
I have added new interactive command '0' (zero), that allows to define how many of existing entries in the host names should be "masked", starting from the top.

Regards,
Chris