### PR TITLE
udp checksum is incorrect

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,8 @@ mtr_packet_SOURCES = \
 	packet/probe.c packet/probe.h \
 	packet/protocols.h \
 	packet/timeval.c packet/timeval.h \
-	packet/wait.h
+	packet/wait.h \
+	packet/sockaddr.c packet/sockaddr.h
 
 mtr_packet_LDADD = $(CAP_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ AS_IF([test "x$with_ncurses" = "xyes"],
 ])
 AM_CONDITIONAL([WITH_CURSES], [test "x$with_ncurses" = xyes])
 
-AC_CHECK_LIB([cap], [cap_set_proc], [],
+AC_CHECK_LIB([cap], [cap_set_proc], [have_cap="yes"],
   AS_IF([test "$host_os" = linux-gnu],
     AC_MSG_WARN([Capabilities support is strongly recommended for increased security.  See SECURITY for more information.])))
 
@@ -243,7 +243,16 @@ AC_ARG_ENABLE([bash-completion],
   [], [enable_bash_completion=yes]
 )
 AM_CONDITIONAL([BUILD_BASH_COMPLETION], [test "x$enable_bash_completion" = xyes])
-
+echo "build options:"
+echo "--------------"
+echo "ipv6    :$USES_IPV6"
+echo "ipinfo  :$with_ipinfo"
+echo "ncurses :$with_ncurses"
+echo "gtk     :$with_gtk"
+echo "cap     :$have_cap"
+echo "libs    :$LIBS"
+echo "cflags  :$CFLAGS"
+echo "--------------"
 # Prepare config.h, Makefile, and output them.
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -92,7 +92,7 @@ void construct_addr_port(
     int port)
 {
     memcpy(addr_with_port, addr, sizeof(struct sockaddr_storage));
-    *(uint16_t *)sockaddr_port_offset(addr) = htons(port);
+    *sockaddr_port_offset(addr) = htons(port);
 }
 
 /*  Construct a header for IP version 4  */
@@ -210,8 +210,8 @@ void set_udp_ports(
 
         udp->checksum = 0;
     }
-    *(uint16_t *)sockaddr_port_offset(&probe->local_addr) = udp->srcport;
-    *(uint16_t *)sockaddr_port_offset(&probe->remote_addr) = udp->dstport;
+    *sockaddr_port_offset(&probe->local_addr) = udp->srcport;
+    *sockaddr_port_offset(&probe->remote_addr) = udp->dstport;
 }
 
 /* Prepend pseudoheader to the udp datagram and calculate checksum */

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -92,7 +92,7 @@ void construct_addr_port(
     int port)
 {
     memcpy(addr_with_port, addr, sizeof(struct sockaddr_storage));
-    *sockaddr_port_offset(addr) = htons(port);
+    *sockaddr_port_offset(addr_with_port) = htons(port);
 }
 
 /*  Construct a header for IP version 4  */

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include "protocols.h"
+#include "sockaddr.h"
 
 /* For Mac OS X and FreeBSD */
 #ifndef SOL_IP
@@ -90,18 +91,8 @@ void construct_addr_port(
     const struct sockaddr_storage *addr,
     int port)
 {
-    struct sockaddr_in *addr4;
-    struct sockaddr_in6 *addr6;
-
     memcpy(addr_with_port, addr, sizeof(struct sockaddr_storage));
-
-    if (addr->ss_family == AF_INET6) {
-        addr6 = (struct sockaddr_in6 *) addr_with_port;
-        addr6->sin6_port = htons(port);
-    } else {
-        addr4 = (struct sockaddr_in *) addr_with_port;
-        addr4->sin_port = htons(port);
-    }
+    *(uint16_t *)sockaddr_port_offset(addr) = htons(port);
 }
 
 /*  Construct a header for IP version 4  */

--- a/packet/construct_unix.h
+++ b/packet/construct_unix.h
@@ -24,11 +24,9 @@
 int construct_packet(
     const struct net_state_t *net_state,
     int *packet_socket,
-    int sequence,
+    struct probe_t *probe,
     char *packet_buffer,
     int packet_buffer_size,
-    const struct sockaddr_storage *dest_sockaddr,
-    const struct sockaddr_storage *src_sockaddr,
     const struct probe_param_t *param);
 
 #endif

--- a/packet/deconstruct_unix.c
+++ b/packet/deconstruct_unix.c
@@ -88,10 +88,10 @@ void handle_inner_udp_packet(
     if (probe->remote_addr.ss_family != remote_addr->ss_family)
         return;
 
-    if (udp->dstport != *(uint16_t *)sockaddr_port_offset(&probe->remote_addr) )
+    if (udp->dstport != *sockaddr_port_offset(&probe->remote_addr) )
         return;
 
-    if (udp->srcport != *(uint16_t *)sockaddr_port_offset(&probe->local_addr) )
+    if (udp->srcport != *sockaddr_port_offset(&probe->local_addr) )
         return;
 
     void *saddr, *daddr;

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -110,7 +110,7 @@ int resolve_probe_addresses(
     if (param->protocol == IPPROTO_ICMP) {
         if ( (src_sockaddr->ss_family == AF_INET && !net_state->platform.ip4_socket_raw) ||
              (src_sockaddr->ss_family == AF_INET6 && !net_state->platform.ip6_socket_raw) )
-            *(uint16_t *)sockaddr_port_offset(src_sockaddr) = htons(getpid());
+            *sockaddr_port_offset(src_sockaddr) = htons(getpid());
     }
 
     return 0;
@@ -319,7 +319,7 @@ int find_source_addr(
        the connect will fail.  We aren't actually sending
        anything to the port.
      */
-    *(uint16_t *)sockaddr_port_offset(&dest_with_port) = htons(1);
+    *sockaddr_port_offset(&dest_with_port) = htons(1);
     len = sockaddr_addr_size(&dest_with_port);
 
     sock = socket(destaddr->ss_family, SOCK_DGRAM, IPPROTO_UDP);
@@ -361,7 +361,7 @@ int find_source_addr(
        Zero the port, as we may later use this address to finding, and
        we don't want to use the port from the socket we just created.
      */
-    *(uint16_t *)sockaddr_port_offset(&srcaddr) = 0;
+    *sockaddr_port_offset(&srcaddr) = 0;
 
     return 0;
 }

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -33,8 +33,6 @@
 #include "timeval.h"
 #include "sockaddr.h"
 
-#define IP_TEXT_LENGTH 64
-
 /*  Convert the destination address from text to sockaddr  */
 int decode_address_string(
     int ip_version,
@@ -244,7 +242,7 @@ void respond_to_probe(
     int mpls_count,
     const struct mpls_label_t *mpls)
 {
-    char ip_text[IP_TEXT_LENGTH];
+    char ip_text[INET6_ADDRSTRLEN];
     char response[COMMAND_BUFFER_SIZE];
     char mpls_str[COMMAND_BUFFER_SIZE];
     int remaining_size;
@@ -266,7 +264,7 @@ void respond_to_probe(
         ip_argument = "ip-4";
     }
 
-    if (inet_ntop(remote_addr->ss_family, sockaddr_addr_offset(remote_addr), ip_text, IP_TEXT_LENGTH) ==
+    if (inet_ntop(remote_addr->ss_family, sockaddr_addr_offset(remote_addr), ip_text, INET6_ADDRSTRLEN) ==
         NULL) {
 
         perror("inet_ntop failure");

--- a/packet/probe.h
+++ b/packet/probe.h
@@ -104,6 +104,10 @@ struct probe_t {
     /*  The address being probed  */
     struct sockaddr_storage remote_addr;
 
+    /* The local address which was used */
+    struct sockaddr_storage local_addr;
+
+
     /*  Platform specific probe tracking  */
     struct probe_platform_t platform;
 };

--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -32,6 +32,7 @@
 
 #include "platform.h"
 #include "protocols.h"
+#include "sockaddr.h"
 #include "construct_unix.h"
 #include "deconstruct_unix.h"
 #include "timeval.h"
@@ -62,13 +63,11 @@ int send_packet(
             if (net_state->platform.ip6_socket_raw) {
                 send_socket = net_state->platform.udp6_send_socket;
             } else {
-                struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)sockaddr;
-
                 send_socket = net_state->platform.ip6_txrx_udp_socket;
                 if (param->dest_port) {
-                    addr_in6->sin6_port = htons(param->dest_port);
+                    *(uint16_t *)sockaddr_port_offset(sockaddr) = htons(param->dest_port);
                 } else {
-                    addr_in6->sin6_port = sequence;
+                    *(uint16_t *)sockaddr_port_offset(sockaddr) = sequence;
                 }
             }
         }
@@ -85,13 +84,11 @@ int send_packet(
                     send_socket = net_state->platform.ip4_txrx_icmp_socket;
                 }
             } else if (param->protocol == IPPROTO_UDP) {
-                struct sockaddr_in *addr_in = (struct sockaddr_in *)sockaddr;
-
                 send_socket = net_state->platform.ip4_txrx_udp_socket;
                 if (param->dest_port) {
-                    addr_in->sin_port = htons(param->dest_port);
+                    *(uint16_t *)sockaddr_port_offset(sockaddr) = htons(param->dest_port);
                 } else {
-                    addr_in->sin_port = sequence;
+                    *(uint16_t *)sockaddr_port_offset(sockaddr) = sequence;
                 }
             }
         }

--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -65,9 +65,9 @@ int send_packet(
             } else {
                 send_socket = net_state->platform.ip6_txrx_udp_socket;
                 if (param->dest_port) {
-                    *(uint16_t *)sockaddr_port_offset(sockaddr) = htons(param->dest_port);
+                    *sockaddr_port_offset(sockaddr) = htons(param->dest_port);
                 } else {
-                    *(uint16_t *)sockaddr_port_offset(sockaddr) = sequence;
+                    *sockaddr_port_offset(sockaddr) = sequence;
                 }
             }
         }
@@ -86,9 +86,9 @@ int send_packet(
             } else if (param->protocol == IPPROTO_UDP) {
                 send_socket = net_state->platform.ip4_txrx_udp_socket;
                 if (param->dest_port) {
-                    *(uint16_t *)sockaddr_port_offset(sockaddr) = htons(param->dest_port);
+                    *sockaddr_port_offset(sockaddr) = htons(param->dest_port);
                 } else {
-                    *(uint16_t *)sockaddr_port_offset(sockaddr) = sequence;
+                    *sockaddr_port_offset(sockaddr) = sequence;
                 }
             }
         }

--- a/packet/sockaddr.c
+++ b/packet/sockaddr.c
@@ -51,7 +51,7 @@ unsigned int sockaddr_size(const void *x)
 	return 0;
 }
 
-void *sockaddr_port_offset(const void *x)
+in_port_t *sockaddr_port_offset(const void *x)
 {
 	if( x == NULL )
 		return NULL;

--- a/packet/sockaddr.c
+++ b/packet/sockaddr.c
@@ -1,0 +1,69 @@
+#include <stddef.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+void *sockaddr_addr_offset(const void *x)
+{
+	if( x == NULL )
+		return NULL;
+
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET )
+	{
+		return ((void *)(x) + offsetof(struct sockaddr_in, sin_addr));
+	}else
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
+	{
+		return ((void *)(x) + offsetof(struct sockaddr_in6, sin6_addr));
+	}
+
+	return NULL;
+}
+
+unsigned int sockaddr_addr_size(const void *x)
+{
+	if( x == NULL )
+		return 0;
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET )
+	{
+		return sizeof(struct in_addr);
+	}else
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
+	{
+		return sizeof(struct in6_addr);
+	}
+	return 0;
+}
+
+
+unsigned int sockaddr_size(const void *x)
+{
+	if( x == NULL )
+		return 0;
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET )
+	{
+		return sizeof(struct sockaddr_in);
+	}else
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
+	{
+		return sizeof(struct sockaddr_in6);
+	}
+	return 0;
+}
+
+void *sockaddr_port_offset(const void *x)
+{
+	if( x == NULL )
+		return NULL;
+
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET )
+	{
+		return ((void *)(x) + offsetof(struct sockaddr_in, sin_port));
+	}else
+	if( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
+	{
+		return ((void *)(x) + offsetof(struct sockaddr_in6, sin6_port));
+	}
+
+	return NULL;
+}

--- a/packet/sockaddr.h
+++ b/packet/sockaddr.h
@@ -1,0 +1,6 @@
+unsigned int sockaddr_size(const void *x);
+
+void *sockaddr_addr_offset(const void *x);
+unsigned int sockaddr_addr_size(const void *x);
+
+void *sockaddr_port_offset(const void *x);

--- a/packet/sockaddr.h
+++ b/packet/sockaddr.h
@@ -3,4 +3,4 @@ unsigned int sockaddr_size(const void *x);
 void *sockaddr_addr_offset(const void *x);
 unsigned int sockaddr_addr_size(const void *x);
 
-void *sockaddr_port_offset(const void *x);
+in_port_t *sockaddr_port_offset(const void *x);


### PR DESCRIPTION
in certain circumstances -I'm aware of specifying localport and port in udp mode- mtr-packet sends udp packets with invalid checksum.

```
"33000 send-probe ip-4 1.1.1.1 local-ip-4 1.2.3.4 protocol udp size 64 bit-pattern 0 tos 0 ttl 1 timeout 10 port 123 local-port 33333 bit-pattern 111" | sudo ./mtr-packet
```

The changes correct this behaviour, they calculate the udp checksum and write to the required offset.