### PR TITLE
Print program name before error messages.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((c-mode . ((indent-tabs-mode  . nil)
+            (c-file-style      . "gnu")
+            (c-basic-offset    . 4))))

--- a/packet/command_unix.c
+++ b/packet/command_unix.c
@@ -19,6 +19,11 @@
 #include "command.h"
 
 #include <errno.h>
+#ifdef HAVE_ERROR_H
+#include <error.h>
+#else
+#include "portability/error.h"
+#endif
 #include <fcntl.h>
 #include <string.h>
 #include <stdio.h>
@@ -41,14 +46,12 @@ void init_command_buffer(
     /*  Get the current command stream flags  */
     flags = fcntl(command_stream, F_GETFL, 0);
     if (flags == -1) {
-        perror("Unexpected command stream error");
-        exit(EXIT_FAILURE);
+        error(EXIT_FAILURE, errno, "Unexpected command stream error");
     }
 
     /*  Set the O_NONBLOCK bit  */
     if (fcntl(command_stream, F_SETFL, flags | O_NONBLOCK)) {
-        perror("Unexpected command stream error");
-        exit(EXIT_FAILURE);
+        error(EXIT_FAILURE, errno, "Unexpected command stream error");
     }
 }
 
@@ -80,8 +83,7 @@ int read_commands(
         /*  EAGAIN simply means there is no available data to read  */
         /*  EINTR indicates we received a signal during read  */
         if (errno != EINTR && errno != EAGAIN) {
-            perror("Unexpected command buffer read error");
-            exit(EXIT_FAILURE);
+            error(EXIT_FAILURE, errno, "Unexpected command buffer read error");
         }
     }
 

--- a/packet/packet.c
+++ b/packet/packet.c
@@ -19,6 +19,11 @@
 #include "config.h"
 
 #include <errno.h>
+#ifdef HAVE_ERROR_H
+#include <error.h>
+#else
+#include "portability/error.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -83,8 +88,7 @@ int main(
      */
     init_net_state_privileged(&net_state);
     if (drop_elevated_permissions()) {
-        perror("Unable to drop elevated permissions");
-        exit(EXIT_FAILURE);
+        error(EXIT_FAILURE, errno, "Unable to drop elevated permissions");
     }
     init_net_state(&net_state);
 

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -21,6 +21,11 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
+#ifdef HAVE_ERROR_H
+#include <error.h>
+#else
+#include "portability/error.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -284,9 +289,7 @@ void respond_to_probe(
 
     if (inet_ntop(remote_addr->ss_family, addr, ip_text, IP_TEXT_LENGTH) ==
         NULL) {
-
-        perror("inet_ntop failure");
-        exit(EXIT_FAILURE);
+        error(EXIT_FAILURE, errno, "inet_ntop failure");
     }
 
     snprintf(response, COMMAND_BUFFER_SIZE,

--- a/packet/wait_unix.c
+++ b/packet/wait_unix.c
@@ -20,6 +20,11 @@
 
 #include <assert.h>
 #include <errno.h>
+#ifdef HAVE_ERROR_H
+#include <error.h>
+#else
+#include "portability/error.h"
+#endif
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -144,8 +149,7 @@ void wait_for_activity(
          */
         if (errno != EINTR && errno != EAGAIN) {
             /*  We don't expect other errors, so report them  */
-            perror("unexpected select error");
-            exit(EXIT_FAILURE);
+            error(EXIT_FAILURE, errno, "unexpected select error");
         }
     }
 }


### PR DESCRIPTION
Print the program name (mtr or mtr-packet) in front of error messages so that a user can distinguish better which part an error occured in.