### PR TITLE
Link portability/error.c with mtr-packet when missing on MacOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,13 @@ mtr_packet_SOURCES = \
 mtr_packet_LDADD = $(CAP_LIBS)
 
 
+if WITH_ERROR
+mtr_packet_SOURCES += \
+	portability/error.h \
+	portability/error.c
+endif
+
+
 if CYGWIN
 
 mtr_packet_SOURCES += \


### PR DESCRIPTION
Change 817f171d broke the MacOS build.

Change 817f171d converted the error reporting in mtr-packet from
perror() to error().  That's fine, but error() is missing on MacOS.
We already had portability/error.c for this reason, but that was
previously only linked into the mtr binary, not mtr-packet.

This change also links portability/error.c with mtr-packet, when
error() is missing from the OS.