### PR TITLE
Fix disappearing URLs in man pages for MacOS

### DIFF
--- a/build-aux/mangen.sh
+++ b/build-aux/mangen.sh
@@ -11,4 +11,19 @@ if [ $# -lt 3 ]; then
     exit 1
 fi
 
-sed -e "s|@VERSION[@]|$1|g" $2 >$3
+TMP_FILE=/tmp/mangen.$$
+
+sed -e "s|@VERSION[@]|$1|g" $2 >$TMP_FILE
+
+#
+#  MacOS's groff is missing .UR and .UE support, which makes
+#  URL completely disappear from man pages.  We need to strip
+#  those codes out when building for MacOS
+#
+if [ $(uname -s) = "Darwin" ]; then
+    sed -e "s|.UR ||g" $TMP_FILE | sed -e "s|.UE||g" > $3
+else
+    cp $TMP_FILE $3
+fi
+
+rm -f $TMP_FILE


### PR DESCRIPTION
groff under MacOS is missing support for .UR and .UE codes, which are
used to embed URLs in man pages.  In fact, using those codes causes
the URLs to disappear from the man page entirely.

With this change, when we generate man pages, strip of the .UR and .UE
codes when building under MacOS.