### PR TITLE
mtr-packet: make address-not-available errors less likely

### DIFF
--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -583,8 +583,11 @@ void send_probe(
 
         if ((param->protocol != IPPROTO_TCP) && 
             (param->protocol != IPPROTO_SCTP)) break; // no retry if not TCP/SCTP
-        if (errno != EADDRINUSE) break; // no retry if not addrinuse.
-        	
+
+        if (errno != EADDRINUSE && errno != EADDRNOTAVAIL) {
+            break; // no retry
+        }
+
      	probe->sequence = net_state->platform.next_sequence++;
         	
        	if (net_state->platform.next_sequence > MAX_PORT) {


### PR DESCRIPTION
Use MIN_PORT to MAX_PORT port range to avoid getting EADDRNOTAVAIL caused by
sockets in FIN-WAIT-1 state.  This issue is easy to reproduce with following
loop (as root).

    src="$(ip route | awk '/default/ {print $9}')"
    while true; do
      echo "6000 send-probe ip-4 1.1.1.1 local-ip-4 $src port 443 protocol tcp" |
      ./mtr-packet
    done | head -n 10
    6000 reply ip-4 1.1.1.1 round-trip-time 11306
    6000 address-not-available
    6000 address-not-available
    [...]

Reported-by: Scott Pearson <scott@cloudflare.com>
Reproeuced-by: Jarred Trainor <jarred@cloudflare.com>
Signed-off-by: Sami Kerola <kerolasa@iki.fi> && <kerolasa@cloudflare.com>