### PR TITLE
asn: always create ipinfo cache

### DIFF
--- a/ui/asn.c
+++ b/ui/asn.c
@@ -313,11 +313,9 @@ int is_printii(
 void asn_open(
     struct mtr_ctl *ctl)
 {
-    if (ctl->ipinfo_no >= 0) {
-        DEB_syslog(LOG_INFO, "hcreate(%d)", IIHASH_HI);
-        if (!(iihash = hcreate(IIHASH_HI)))
-            error(0, errno, "ipinfo hash");
-    }
+    DEB_syslog(LOG_INFO, "hcreate(%d)", IIHASH_HI);
+    if (!(iihash = hcreate(IIHASH_HI)))
+        error(0, errno, "ipinfo hash");
 }
 
 void asn_close(


### PR DESCRIPTION
We currently have two ways of displaying ASN and other IP information:

1) via a command-line switch (-z or -y)

2) interactively by pressing "z" or "y"

For some reason, we were only creating a cache in the first case, leading
to a high number of repeated DNS queries in the second case.  Fix this by
always creating the cache.