### PR TITLE
fix segmentation fault if there is no IP address on an interface (fixes #320)

### DIFF
--- a/ui/net.c
+++ b/ui/net.c
@@ -629,7 +629,7 @@ static void net_find_interface_address_from_name(
 
     interface = ifaddrs;
     while (interface != NULL) {
-        if (!strcmp(interface->ifa_name, interface_name)) {
+        if (interface->ifa_addr != NULL && !strcmp(interface->ifa_name, interface_name)) {
             found_interface_name = 1;
 
             if (interface->ifa_addr->sa_family == address_family) {


### PR DESCRIPTION
It only tries to get the IP address if there is one.
The interface might be listed more than once, so it still finds the IP address of my tunnel interface I tested on. Else it will fall back to normal error handling.