### PR TITLE
Destination hostname displayed in curses.

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -685,7 +685,6 @@ void mtr_curses_redraw(
     char buf[1024];
     char fmt[16];
 
-
     erase();
     getmaxyx(stdscr, __unused_int, maxx);
 
@@ -698,7 +697,11 @@ void mtr_curses_redraw(
     pwcenter(buf);
     attroff(A_BOLD);
 
-    mvprintw(1, 0, "%s (%s)", ctl->LocalHostname, net_localaddr());
+    //printw(fmt_ipinfo(ctl, addr));
+    //printw("%s", name);
+
+
+    mvprintw(1, 0, "%s (%s), %s %s", ctl->LocalHostname, net_localaddr(), " --> ", ctl->Hostname);
     t = time(NULL);
     mvprintw(1, maxx - 25, iso_time(&t));
     printw("\n");

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -685,7 +685,8 @@ void mtr_curses_redraw(
     char buf[1024];
     char fmt[16];
 
-    erase();
+    
+	erase();
     getmaxyx(stdscr, __unused_int, maxx);
 
     rowstat = 5;
@@ -696,10 +697,6 @@ void mtr_curses_redraw(
              PACKAGE_VERSION, "]");
     pwcenter(buf);
     attroff(A_BOLD);
-
-    //printw(fmt_ipinfo(ctl, addr));
-    //printw("%s", name);
-
 
     mvprintw(1, 0, "%s (%s), %s %s", ctl->LocalHostname, net_localaddr(), " --> ", ctl->Hostname);
     t = time(NULL);


### PR DESCRIPTION
I run multiple mtr's in different windows to monitor several networks. I wanted to be able to quickly identify which window belonged to which network.