### PR TITLE
Add display of destination.

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -698,7 +698,7 @@ void mtr_curses_redraw(
     pwcenter(buf);
     attroff(A_BOLD);
 
-    mvprintw(1, 0, "%s (%s)", ctl->LocalHostname, net_localaddr());
+    mvprintw(1, 0, "%s (%s) -> %s", ctl->LocalHostname, net_localaddr(), ctl->Hostname);
     t = time(NULL);
     mvprintw(1, maxx - 25, iso_time(&t));
     printw("\n");


### PR DESCRIPTION
This is a clean version of #337 without the extra commits and whitespace changes.
This should also fix issue #230 as it appears to be the same.

As mentioned in the issue and previous PR, this feature would be extremely useful when running multiple copies of `mtr` to different destinations.