### PR TITLE
report: json: reworked with libjansson

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,8 +92,8 @@ ASAN_CFLAGS += -fsanitize=address
 endif
 
 mtr_INCLUDES = $(GLIB_CFLAGS) -I$(top_builddir) -I$(top_srcdir)
-mtr_CFLAGS = $(GTK_CFLAGS) $(NCURSES_CFLAGS) $(ASAN_CFLAGS)
-mtr_LDADD = $(GTK_LIBS) $(NCURSES_LIBS) $(RESOLV_LIBS)
+mtr_CFLAGS = $(GTK_CFLAGS) $(NCURSES_CFLAGS) $(ASAN_CFLAGS) $(JANSSON_CFLAGS)
+mtr_LDADD = $(GTK_LIBS) $(NCURSES_LIBS) $(RESOLV_LIBS) $(JANSSON_LIBS)
 
 
 mtr_packet_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,15 @@ AS_IF([test "x$with_gtk" = "xyes"],
 ])
 AM_CONDITIONAL([WITH_GTK], [test "x$with_gtk" = xyes])
 
+AC_ARG_WITH([jansson],
+  [AS_HELP_STRING([--without-jansson], [Build without JSON output])],
+  [], [with_jansson=yes])
+AS_IF([test "x$with_jansson" = "xyes"],
+  [PKG_CHECK_MODULES([JANSSON], [jansson],
+    [AC_DEFINE([HAVE_JANSSON], [1], [Define if jansson library available])],
+    [with_jansson=no])
+])
+
 # Find ncurses
 AC_ARG_WITH([ncurses],
   [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
@@ -259,6 +268,7 @@ echo "ipv6    :$USES_IPV6"
 echo "ipinfo  :$with_ipinfo"
 echo "ncurses :$with_ncurses"
 echo "gtk     :$with_gtk"
+echo "jansson :$with_jansson"
 echo "cap     :$have_cap"
 echo "libs    :$LIBS"
 echo "cflags  :$CFLAGS"

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -267,6 +267,9 @@ Use this option to tell
 .B mtr
 to use the JSON output format.  This format is better suited for
 automated processing of the measurement results.
+Jansson library must have been available on the system when
+.B mtr
+was built for this to work.
 .TP
 .B \-p\fR, \fB\-\-split
 Use this option to set

--- a/ui/display.c
+++ b/ui/display.c
@@ -81,9 +81,11 @@ void display_open(
     case DisplayTXT:
         txt_open();
         break;
+#ifdef HAVE_JANSSON
     case DisplayJSON:
         json_open();
         break;
+#endif
     case DisplayXML:
         xml_open();
         break;
@@ -127,9 +129,11 @@ void display_close(
     case DisplayTXT:
         txt_close(ctl);
         break;
+#ifdef HAVE_JANSSON
     case DisplayJSON:
         json_close(ctl);
         break;
+#endif
     case DisplayXML:
         xml_close(ctl);
         break;

--- a/ui/display.h
+++ b/ui/display.h
@@ -41,7 +41,9 @@ enum {
     DisplayXML,
     DisplayCSV,
     DisplayTXT,
-    DisplayJSON
+#ifdef HAVE_JANSSON
+    DisplayJSON,
+#endif
 };
 
 enum {

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -349,7 +349,9 @@ static void parse_arg(
 #endif
         {"raw", 0, NULL, 'l'},
         {"csv", 0, NULL, 'C'},
+#ifdef HAVE_JANSSON
         {"json", 0, NULL, 'j'},
+#endif
         {"displaymode", 1, NULL, OPT_DISPLAYMODE},
         {"split", 0, NULL, 'p'},        /* BL */
         /* maybe above should change to -d 'x' */
@@ -445,9 +447,11 @@ static void parse_arg(
         case 'C':
             ctl->DisplayMode = DisplayCSV;
             break;
+#ifdef HAVE_JANSSON
         case 'j':
             ctl->DisplayMode = DisplayJSON;
             break;
+#endif
         case 'x':
             ctl->DisplayMode = DisplayXML;
             break;
@@ -644,7 +648,9 @@ static void parse_arg(
 
     if (ctl->DisplayMode == DisplayReport ||
         ctl->DisplayMode == DisplayTXT ||
+#ifdef HAVE_JANSSON
         ctl->DisplayMode == DisplayJSON ||
+#endif
         ctl->DisplayMode == DisplayXML ||
         ctl->DisplayMode == DisplayRaw || ctl->DisplayMode == DisplayCSV)
         ctl->Interactive = 0;


### PR DESCRIPTION
I reworked JSON report to use libjansson. Consider such solution more robust.
I noticed that fixes JSON output when no hosts:
<details>
  <summary>Screenshot with comparison</summary>
  <img src="https://user-images.githubusercontent.com/6095240/87069694-52ac7f80-c220-11ea-9da1-138962b1d05e.png" alt="drawing" width="500"/>
</details>
Also, it changes the following:

- report.mtr.{tests, tos} now output as number;
- report.hubs[].count now output as number;
- the precision of real numbers differs;

<details>
  <summary>Screenshot with comparison</summary>
  <img src="https://user-images.githubusercontent.com/6095240/87070213-20e7e880-c221-11ea-88e7-dd4a083b6301.png" alt="drawing" width="400"/>
</details>