### PR TITLE
Fixes to make it behave more like stable 0.87

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -71,19 +71,6 @@ uint16_t compute_checksum(
     return (~sum & 0xffff);
 }
 
-/*  Encode the IP header length field in the order required by the OS.  */
-static
-uint16_t length_byte_swap(
-    const struct net_state_t *net_state,
-    uint16_t length)
-{
-    if (net_state->platform.ip_length_host_order) {
-        return length;
-    } else {
-        return htons(length);
-    }
-}
-
 /*  Construct a combined sockaddr from a source address and source port  */
 static
 void construct_addr_port(
@@ -95,38 +82,9 @@ void construct_addr_port(
     *sockaddr_port_offset(addr_with_port) = htons(port);
 }
 
-/*  Construct a header for IP version 4  */
-static
-void construct_ip4_header(
-    const struct net_state_t *net_state,
-    const struct probe_t *probe,
-    char *packet_buffer,
-    int packet_size,
-    const struct probe_param_t *param)
-{
-    struct IPHeader *ip;
-
-    ip = (struct IPHeader *) &packet_buffer[0];
-
-    memset(ip, 0, sizeof(struct IPHeader));
-
-    ip->version = 0x45;
-    ip->tos = param->type_of_service;
-    ip->len = length_byte_swap(net_state, packet_size);
-    ip->ttl = param->ttl;
-    ip->protocol = param->protocol;
-//    ip->id = htons(getpid());
-    memcpy(&ip->saddr,
-           sockaddr_addr_offset(&probe->local_addr),
-           sockaddr_addr_size(&probe->local_addr));
-    memcpy(&ip->daddr,
-           sockaddr_addr_offset(&probe->remote_addr),
-           sockaddr_addr_size(&probe->remote_addr));
-}
-
 /*  Construct an ICMP header for IPv4  */
 static
-void construct_icmp4_header(
+int construct_icmp4_packet(
     const struct net_state_t *net_state,
     struct probe_t *probe,
     char *packet_buffer,
@@ -134,22 +92,17 @@ void construct_icmp4_header(
     const struct probe_param_t *param)
 {
     struct ICMPHeader *icmp;
-    int icmp_size;
 
-    if (net_state->platform.ip4_socket_raw) {
-        icmp = (struct ICMPHeader *) &packet_buffer[sizeof(struct IPHeader)];
-        icmp_size = packet_size - sizeof(struct IPHeader);
-    } else {
-        icmp = (struct ICMPHeader *) &packet_buffer[0];
-        icmp_size = packet_size;
-    }
+    icmp = (struct ICMPHeader *) packet_buffer;
 
     memset(icmp, 0, sizeof(struct ICMPHeader));
 
     icmp->type = ICMP_ECHO;
     icmp->id = htons(getpid());
     icmp->sequence = htons(probe->sequence);
-    icmp->checksum = htons(compute_checksum(icmp, icmp_size));
+    icmp->checksum = htons(compute_checksum(icmp, packet_size));
+
+    return 0;
 }
 
 /*  Construct an ICMP header for IPv6  */
@@ -238,7 +191,7 @@ int udp4_checksum(void *pheader, void *udata, int psize, int dsize,
     with the probe.
 */
 static
-void construct_udp4_header(
+int construct_udp4_packet(
     const struct net_state_t *net_state,
     struct probe_t *probe,
     char *packet_buffer,
@@ -248,13 +201,8 @@ void construct_udp4_header(
     struct UDPHeader *udp;
     int udp_size;
 
-    if (net_state->platform.ip4_socket_raw) {
-        udp = (struct UDPHeader *) &packet_buffer[sizeof(struct IPHeader)];
-        udp_size = packet_size - sizeof(struct IPHeader);
-    } else {
-        udp = (struct UDPHeader *) &packet_buffer[0];
-        udp_size = packet_size;
-    }
+    udp = (struct UDPHeader *) packet_buffer;
+    udp_size = packet_size;
 
     memset(udp, 0, sizeof(struct UDPHeader));
 
@@ -283,6 +231,8 @@ void construct_udp4_header(
     *checksum_off = htons(udp4_checksum(&udph, udp,
                                         sizeof(struct UDPPseudoHeader),
                                         udp_size, udp->checksum != 0));
+
+    return 0;
 }
 
 /*  Construct a header for UDPv6 probes  */
@@ -545,10 +495,10 @@ int construct_ip4_packet(
     int packet_size,
     const struct probe_param_t *param)
 {
-    int send_socket = net_state->platform.ip4_send_socket;
+    int send_socket;
     bool is_stream_protocol = false;
-    int tos, ttl, socket;
-    bool bind_send_socket = false;
+    int tos, ttl;
+    bool bind_send_socket = true;
     struct sockaddr_storage current_sockaddr;
     int current_sockaddr_len;
 
@@ -558,22 +508,33 @@ int construct_ip4_packet(
     } else if (param->protocol == IPPROTO_SCTP) {
         is_stream_protocol = true;
 #endif
-    } else {
+    } else if (param->protocol == IPPROTO_ICMP) {
         if (net_state->platform.ip4_socket_raw) {
-            construct_ip4_header(net_state, probe, packet_buffer, packet_size,
-                                  param);
-        }
-        if (param->protocol == IPPROTO_ICMP) {
-            construct_icmp4_header(net_state, probe, packet_buffer,
-                                   packet_size, param);
-        } else if (param->protocol == IPPROTO_UDP) {
-            construct_udp4_header(net_state, probe, packet_buffer,
-                                  packet_size, param);
+            send_socket = net_state->platform.icmp4_send_socket;
         } else {
-            errno = EINVAL;
+            send_socket = net_state->platform.ip4_txrx_icmp_socket;
+        }
+
+        if (construct_icmp4_packet
+            (net_state, probe, packet_buffer, packet_size, param)) {
             return -1;
         }
+    } else if (param->protocol == IPPROTO_UDP) {
+        if (net_state->platform.ip4_socket_raw) {
+            send_socket = net_state->platform.udp4_send_socket;
+        } else {
+            send_socket = net_state->platform.ip4_txrx_udp_socket;
+        }
+
+        if (construct_udp4_packet
+            (net_state, probe, packet_buffer, packet_size, param)) {
+            return -1;
+        }
+    } else {
+        errno = EINVAL;
+        return -1;
     }
+
 
     if (is_stream_protocol) {
         send_socket =
@@ -608,53 +569,50 @@ int construct_ip4_packet(
 #endif
 
     /*
-       Bind src port when not using raw socket to pass in ICMP id, kernel
-       get ICMP id from src_port when using DGRAM socket.
+       Check the current socket address, and if it is the same
+       as the source address we intend, we will skip the bind.
+       This is to accommodate Solaris, which, as of Solaris 11.3,
+       will return an EINVAL error on bind if the socket is already
+       bound, even if the same address is used.
      */
-    if (!net_state->platform.ip4_socket_raw &&
-            param->protocol == IPPROTO_ICMP &&
-            !param->is_probing_byte_order) {
-        current_sockaddr_len = sizeof(struct sockaddr_in);
-        bind_send_socket = true;
-        socket = net_state->platform.ip4_txrx_icmp_socket;
-        if (getsockname(socket, (struct sockaddr *) &current_sockaddr,
-                        &current_sockaddr_len)) {
-            return -1;
-        }
-        struct sockaddr_in *sin_cur =
-            (struct sockaddr_in *) &current_sockaddr;
+    current_sockaddr_len = sizeof(struct sockaddr_in);
+    if (getsockname(send_socket, (struct sockaddr *) &current_sockaddr,
+                    &current_sockaddr_len) == 0) {
+        struct sockaddr_in *sin_cur = (struct sockaddr_in *) &current_sockaddr;
 
-        /* avoid double bind */
-        if (sin_cur->sin_port) {
-            bind_send_socket = false;
+        if (net_state->platform.ip4_socket_raw) {
+            if (memcmp(&current_sockaddr,
+                       &probe->local_addr, sizeof(struct sockaddr_in)) == 0) {
+                bind_send_socket = false;
+            }
+        } else {
+            /* avoid double bind for DGRAM socket */
+            if (sin_cur->sin_port) {
+                bind_send_socket = false;
+            }
         }
     }
 
     /*  Bind to our local address  */
-    if (bind_send_socket && bind(socket, (struct sockaddr *)&probe->local_addr,
+    if (bind_send_socket && bind(send_socket, (struct sockaddr *)&probe->local_addr,
                 sizeof(struct sockaddr_in))) {
         return -1;
     }
 
-    /* set TOS and TTL for non-raw socket */
-    if (!net_state->platform.ip4_socket_raw && !param->is_probing_byte_order) {
-        if (param->protocol == IPPROTO_ICMP) {
-            socket = net_state->platform.ip4_txrx_icmp_socket;
-        } else if (param->protocol == IPPROTO_UDP) {
-            socket = net_state->platform.ip4_txrx_udp_socket;
-        } else {
-            return 0;
-        }
-        tos = param->type_of_service;
-        if (setsockopt(socket, SOL_IP, IP_TOS, &tos, sizeof(int))) {
-            return -1;
-        }
-        ttl = param->ttl;
-        if (setsockopt(socket, SOL_IP, IP_TTL,
-                       &ttl, sizeof(int)) == -1) {
-            return -1;
-        }
+    /*  Set the type of service  */
+    tos = param->type_of_service;
+    if (setsockopt(send_socket, SOL_IP, IP_TOS, &tos, sizeof(int))) {
+        return -1;
     }
+
+    /*  Set the time-to-live  */
+    ttl = param->ttl;
+    if (setsockopt(send_socket, SOL_IP, IP_TTL,
+                   &ttl, sizeof(int)) == -1) {
+        return -1;
+    }
+
+
 
     return 0;
 }

--- a/packet/deconstruct_unix.c
+++ b/packet/deconstruct_unix.c
@@ -534,35 +534,17 @@ void handle_received_ip4_packet(
     int packet_length,
     struct timeval *timestamp)
 {
-    int ip_icmp_size = 0;
     const struct IPHeader *ip;
     const struct ICMPHeader *icmp;
-    int icmp_length;
-
-    if (net_state->platform.ip4_socket_raw) {
-        ip_icmp_size += sizeof(struct IPHeader);
-    }
-    ip_icmp_size += sizeof(struct ICMPHeader);
-
-    /*  Ensure that we don't access memory beyond the bounds of the packet  */
-    if (packet_length < ip_icmp_size) {
-        return;
-    }
 
     if (net_state->platform.ip4_socket_raw) {
         ip = (struct IPHeader *) packet;
-        if (ip->protocol != IPPROTO_ICMP) {
-            return;
-        }
-
         icmp = (struct ICMPHeader *) (ip + 1);
-        icmp_length = packet_length - sizeof(struct IPHeader);
     } else {
         icmp = (struct ICMPHeader *) packet;
-        icmp_length = packet_length;
     }
 
-    handle_received_icmp4_packet(net_state, remote_addr, icmp, icmp_length,
+    handle_received_icmp4_packet(net_state, remote_addr, icmp, packet_length,
                                  timestamp);
 }
 

--- a/packet/probe_unix.h
+++ b/packet/probe_unix.h
@@ -54,8 +54,11 @@ struct net_state_platform_t {
     /* true if ipv6 socket is raw socket */
     bool ip6_socket_raw;
 
-    /*  Socket used to send raw IPv4 packets  */
-    int ip4_send_socket;
+    /*  Send socket for ICMPv6 packets  */
+    int icmp4_send_socket;
+
+    /*  Send socket for UDPv6 packets  */
+    int udp4_send_socket;
 
     /*  Socket used to receive IPv4 ICMP replies  */
     int ip4_recv_socket;

--- a/packet/probe_unix.h
+++ b/packet/probe_unix.h
@@ -54,10 +54,10 @@ struct net_state_platform_t {
     /* true if ipv6 socket is raw socket */
     bool ip6_socket_raw;
 
-    /*  Send socket for ICMPv6 packets  */
+    /*  Send socket for ICMPv4 packets  */
     int icmp4_send_socket;
 
-    /*  Send socket for UDPv6 packets  */
+    /*  Send socket for UDPv4 packets  */
     int udp4_send_socket;
 
     /*  Socket used to receive IPv4 ICMP replies  */

--- a/ui/net.c
+++ b/ui/net.c
@@ -47,8 +47,8 @@
 static int packetsize;          /* packet size used by ping */
 
 struct nethost {
-    ip_t addr;                  /* Latest host to respond */
-    ip_t addrs[MAX_PATH];        /* For Multi paths/Path Changes: List of all hosts that have responded */
+    ip_t addr;
+    ip_t addrs[MAX_PATH];        /* for multi paths byMin */
     int err;
     int xmit;
     int returned;
@@ -219,7 +219,6 @@ static void net_process_ping(
     int oldavg;                 /* usedByMin */
     int oldjavg;                /* usedByMin */
     int i;                      /* usedByMin */
-    int found = 0;
 #ifdef ENABLE_IPV6
     char addrcopy[sizeof(struct in6_addr)];
 #else
@@ -238,32 +237,30 @@ static void net_process_ping(
 
 
 
-    if (addrcmp(&nh->addr, &addrcopy, ctl->af) != 0) {
+    if (addrcmp(&nh->addr, &ctl->unspec_addr, ctl->af) == 0) {
+        /* should be out of if as addr can change */
+        memcpy(&nh->addr, addrcopy, sockaddr_addr_size(sourcesockaddr));
+        nh->mpls = *mpls;
+        display_rawhost(ctl, index, (void *)&(nh->addr), (void *)&(nh->mpls));
+
+        /* multi paths */
+        memcpy(&nh->addrs[0], addrcopy, sockaddr_addr_size(sourcesockaddr));
+        nh->mplss[0] = *mpls;
+    } else {
         for (i = 0; i < MAX_PATH;) {
-            if (addrcmp(&nh->addrs[i], &nh->addr, ctl->af) == 0) {
-                found = 1; /* This host is already in the list */
+            if (addrcmp(&nh->addrs[i], &addrcopy, ctl->af) == 0 ||
+                addrcmp(&nh->addrs[i], &ctl->unspec_addr, ctl->af) == 0) {
                 break;
-            }
-            if (addrcmp(&nh->addrs[i], &ctl->unspec_addr, ctl->af) == 0) {
-                break; /* Found first vacant position */
             }
             i++;
         }
 
-        if (found == 0 && i < MAX_PATH) {
-            memcpy(&nh->addrs[i], &nh->addr, sockaddr_addr_size(sourcesockaddr));
+        if (addrcmp(&nh->addrs[i], &addrcopy, ctl->af) != 0 && i < MAX_PATH) {
+            memcpy(&nh->addrs[i], addrcopy, sockaddr_addr_size(sourcesockaddr));
 
-            nh->mplss[i] = nh->mpls;
+            nh->mplss[i] = *mpls;
             display_rawhost(ctl, index, (void *)&(nh->addrs[i]), (void *)&(nh->addrs[i]));
         }
-
-        /* Always save the latest host in nh->addr. This
-         * allows maxTTL to change whenever path changes.
-         */
-        memcpy(&nh->addr, addrcopy, sockaddr_addr_size(sourcesockaddr));
-        nh->mpls = *mpls;
-        nh->mplss[0] = *mpls;
-        display_rawhost(ctl, index, (void *)&(nh->addr), (void *)&(nh->mpls));
     }
 
     nh->jitter = totusec - nh->last;
@@ -538,7 +535,6 @@ int net_send_batch(
     struct mtr_ctl *ctl)
 {
     int n_unknown = 0, i;
-    int restart = 0;
 
     /* randomized packet size and/or bit pattern if packetsize<0 and/or 
        bitpattern<0.  abs(packetsize) and/or abs(bitpattern) will be used 
@@ -576,11 +572,8 @@ int net_send_batch(
            hosts. Removed in 0.65. 
            If the line proves necessary, it should at least NOT trigger that line
            when host[i].addr == 0 */
-        if (host_addr_cmp(i, remoteaddress, ctl->af) == 0) {
-            restart = 1;
-            numhosts = i + 1; /* Saves batch_at - index number of probes in the next round!*/
-            break;
-        }
+        if (host_addr_cmp(i, remoteaddress, ctl->af) == 0)
+            n_unknown = MaxHost;        /* Make sure we drop into "we should restart" */
     }
 
     if (                        /* success in reaching target */
@@ -589,11 +582,7 @@ int net_send_batch(
            (n_unknown > ctl->maxUnknown) ||
            /* or reach limit  */
            (batch_at >= ctl->maxTTL - 1)) {
-        restart = 1;
         numhosts = batch_at + 1;
-    }
-
-    if(restart) {
         batch_at = ctl->fstTTL - 1;
         return 1;
     }

--- a/ui/net.c
+++ b/ui/net.c
@@ -262,6 +262,7 @@ static void net_process_ping(
          */
         memcpy(&nh->addr, addrcopy, sockaddr_addr_size(sourcesockaddr));
         nh->mpls = *mpls;
+        nh->mplss[0] = *mpls;
         display_rawhost(ctl, index, (void *)&(nh->addr), (void *)&(nh->mpls));
     }
 

--- a/ui/report.c
+++ b/ui/report.c
@@ -184,8 +184,8 @@ void report_close(
 
         /* This feature shows 'loadbalances' on routes */
 
-        /* Print list of all hosts that have responded from ttl = at + 1 away */
-        for (z = 0; z < MAX_PATH; z++) {
+        /* z is starting at 1 because addrs[0] is the same that addr */
+        for (z = 1; z < MAX_PATH; z++) {
             int found = 0;
             addr2 = net_addrs(at, z);
             mplss = net_mplss(at, z);
@@ -193,10 +193,6 @@ void report_close(
                  ((void *) &ctl->unspec_addr, (void *) addr2,
                   ctl->af)) == 0) {
                 break;
-            } else if ((addrcmp
-                        ((void *) addr, (void *) addr2,
-                          ctl->af)) == 0) {
-                continue; /* Latest Host is already printed */
             } else {
                 snprint_addr(ctl, name, sizeof(name), addr2);
                 snprintf(fmt, sizeof(fmt), "        %%-%zus", len_hosts);


### PR DESCRIPTION
* Fix for #232  #250 
* Reverted d2552ca because it breaks MPLS and hosts start jumping up and down in the interactive display


I'm not certain about some things in deconstruct_unix (why (struct ICMPHeader *) (ip + 1) in handle_received_ip4_packet? It should be the same for both sockets.

But I don't have any more time/energy to work on improving it further.