### PR TITLE
Add display of destination with resolved addr under curses mode

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -698,7 +698,7 @@ void mtr_curses_redraw(
     pwcenter(buf);
     attroff(A_BOLD);
 
-    mvprintw(1, 0, "%s (%s) -> %s", ctl->LocalHostname, net_localaddr(), ctl->Hostname);
+    mvprintw(1, 0, "%s (%s) -> %s (%s)", ctl->LocalHostname, net_localaddr(), ctl->Hostname, net_remoteaddr());
     t = time(NULL);
     mvprintw(1, maxx - 25, iso_time(&t));
     printw("\n");

--- a/ui/net.c
+++ b/ui/net.c
@@ -97,11 +97,13 @@ static ip_t *remoteaddress;
 
 #ifdef ENABLE_IPV6
 static char localaddr[INET6_ADDRSTRLEN];
+static char remoteaddr[INET6_ADDRSTRLEN];
 #else
 #ifndef INET_ADDRSTRLEN
 #define INET_ADDRSTRLEN 16
 #endif
 static char localaddr[INET_ADDRSTRLEN];
+static char remoteaddr[INET_ADDRSTRLEN];
 #endif
 
 static int batch_at = 0;
@@ -523,6 +525,13 @@ char *net_localaddr(
 }
 
 
+char *net_remoteaddr(
+    void)
+{
+    return remoteaddr;
+}
+
+
 void net_end_transit(
     void)
 {
@@ -755,6 +764,8 @@ int net_open(
     } else {
         net_find_local_address();
     }
+
+    inet_ntop(remotesockaddr->sa_family, sockaddr_addr_offset(remotesockaddr), remoteaddr, sizeof(remoteaddr));
 
     return 0;
 }

--- a/ui/net.h
+++ b/ui/net.h
@@ -90,6 +90,8 @@ extern ip_t *net_addrs(
     int i);
 extern char *net_localaddr(
     void);
+extern char *net_remoteaddr(
+    void);
 
 extern int net_send_batch(
     struct mtr_ctl *ctl);


### PR DESCRIPTION
This PR is a further extension of #345 

With the consideration of symmetry, since we display the local hostname with its source address, we should also display the remote hostname with its remote address.

This change also adds more information when running multiple `mtr` as #345 intended to do.

To keep the symmetry, codes were added following the original style, namely replicas of `localaddr` and `net_localaddr` were made.

The new static char array `remoteaddr` can be used in other modes like report or gtk. This consideration is for further development. Not to be addressed in this PR.

