### PR TITLE
ui: don't cast to void* when calling display_rawhost()

### DIFF
--- a/ui/net.c
+++ b/ui/net.c
@@ -256,7 +256,7 @@ static void net_process_ping(
             memcpy(&nh->addrs[i], &nh->addr, sockaddr_addr_size(sourcesockaddr));
 
             nh->mplss[i] = nh->mpls;
-            display_rawhost(ctl, index, (void *)&(nh->addrs[i]), (void *)&(nh->addrs[i]));
+            display_rawhost(ctl, index, &nh->addrs[i], &nh->mpls);
         }
 
         /* Always save the latest host in nh->addr. This
@@ -264,7 +264,7 @@ static void net_process_ping(
          */
         memcpy(&nh->addr, addrcopy, sockaddr_addr_size(sourcesockaddr));
         nh->mpls = *mpls;
-        display_rawhost(ctl, index, (void *)&(nh->addr), (void *)&(nh->mpls));
+        display_rawhost(ctl, index, &nh->addr, &nh->mpls);
     }
 
     nh->jitter = totusec - nh->last;


### PR DESCRIPTION
The provided types are compatible with the function signature.
Moreover, this seems to hide a bug where `display_rawhost()` is called
with an address instead of an MPLS struct.