### PR TITLE
report: fix display of MPLS labels when using --report

### DIFF
--- a/ui/report.c
+++ b/ui/report.c
@@ -215,14 +215,14 @@ void report_close(
             if (!found) {
 
 #ifdef HAVE_IPINFO
+                if (mpls->labels && z == 1 && ctl->enablempls)
+                    print_mpls(mpls);
                 if (is_printii(ctl)) {
-                    if (mpls->labels && z == 1 && ctl->enablempls)
-                        print_mpls(mpls);
                     snprint_addr(ctl, name, sizeof(name), addr2);
                     printf("     %s%s\n", fmt_ipinfo(ctl, addr2), name);
-                    if (ctl->enablempls)
-                        print_mpls(mplss);
                 }
+                if (ctl->enablempls)
+                    print_mpls(mplss);
 #else
                 int k;
                 if (mpls->labels && z == 1 && ctl->enablempls) {


### PR DESCRIPTION
Previously, using --report --mpls would not display MPLS labels unless
combined with --aslookup or -y. Fix this case.

```
 23:03 ❱ ./mtr  -z --report-wide -e 203.0.113.10
Start: 2021-03-09T23:03:43+0100
HOST: H1                    Loss%   Snt   Last   Avg  Best  Wrst StDev
  1. AS???    192.0.2.1      0.0%    10    1.0   1.1   0.8   1.8   0.3
  2. AS???    169.254.0.2    0.0%    10    2.5   2.5   2.4   2.8   0.1
       [MPLS: Lbl 299776 TC 0 S u TTL 1]
       [MPLS: Lbl 16 TC 0 S u TTL 1]
  3. AS???    203.0.113.1    0.0%    10    2.2   2.7   2.1   4.8   1.1
  4. AS???    203.0.113.10   0.0%    10    2.3   2.3   2.2   2.6   0.1
 23:04 ❱ ./mtr   --report-wide -e 203.0.113.10
Start: 2021-03-09T23:04:07+0100
HOST: H1           Loss%   Snt   Last   Avg  Best  Wrst StDev
  1.|-- 192.0.2.1     0.0%    10    0.8   2.9   0.7  20.9   6.3
  2.|-- 169.254.0.2   0.0%    10    2.8   2.7   2.4   2.8   0.1
       [MPLS: Lbl 299776 TC 0 S u TTL 1]
       [MPLS: Lbl 16 TC 0 S u TTL 1]
  3.|-- 203.0.113.1   0.0%    10   16.1   3.7   2.0  16.1   4.4
  4.|-- 203.0.113.10  0.0%    10    3.5   2.5   2.2   3.5   0.4
```

This is not really elegant and I didn't try to display with vertical
bars like it should be done when no additional IP info is requested,
but the code already has many branches with very similar code and I
didn't want to add even more complexity to it.

Fix #341