### PR TITLE
tell dns process which family we want resolved

### DIFF
--- a/ui/dns.c
+++ b/ui/dns.c
@@ -124,7 +124,7 @@ static void set_sockaddr_ip(
 }
 
 void dns_open(
-    sa_family_t family)
+    void)
 {
     int pid;
 
@@ -173,7 +173,8 @@ void dns_open(
 
                 buf[strlen(buf) - 1] = 0;       /* chomp newline. */
 
-                longipstr(buf, &host, family);
+                sa_family_t family = (buf[0] == '4') ? AF_INET : AF_INET6;
+                longipstr(buf +1, &host, family);
                 set_sockaddr_ip(family, &sa, &host);
                 salen = (family == AF_INET) ? sizeof(struct sockaddr_in) :
                     sizeof(struct sockaddr_in6);
@@ -256,7 +257,7 @@ char *dns_lookup2(
     ip_t * ip)
 {
     struct dns_results *r;
-    char buf[INET6_ADDRSTRLEN + 1];
+    char buf[INET6_ADDRSTRLEN + 2]; // af_byte + addr + null
     int rv;
 
     r = findip(ctl, ip);
@@ -270,7 +271,8 @@ char *dns_lookup2(
         r->name = NULL;
         r->next = results;
         results = r;
-        snprintf(buf, sizeof(buf), "%s\n", strlongip(ctl->af, ip));
+        char ip4or6 = (ctl->af == AF_INET) ? '4' : '6';
+        snprintf(buf, sizeof(buf), "%c%s\n", ip4or6, strlongip(ctl->af, ip));
         rv = write(todns[1], buf, strlen(buf));
         if (rv < 0)
             error(0, errno, "couldn't write to resolver process");

--- a/ui/dns.h
+++ b/ui/dns.h
@@ -23,7 +23,7 @@
 /*  Prototypes for dns.c  */
 
 extern void dns_open(
-    sa_family_t family);
+    void);
 extern int dns_waitfd(
     void);
 extern void dns_ack(

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -858,7 +858,7 @@ int main(
         }
 
         lock(stdout);
-        dns_open(ctl.af);
+        dns_open();
         display_open(&ctl);
 
         display_loop(&ctl);


### PR DESCRIPTION
[edit] was addressing 378
In particular addresses the case where changing from one address family to another. ie when launching mtr with an ipv6 address, then in the gtk interface changing to an ipv4 address.

@robert-scheck I currently cannot test this, are you able to see if it addresses your use case?