### PR TITLE
Adjust MIN_PORT to match other implementations

### DIFF
--- a/packet/probe_unix.h
+++ b/packet/probe_unix.h
@@ -25,7 +25,7 @@
 #endif
 
 /*  The range of local port numbers to use for probes  */
-#define MIN_PORT 33000
+#define MIN_PORT 33434
 #define MAX_PORT 65535
 
 /*  We need to track the transmission and timeouts on Unix systems  */


### PR DESCRIPTION
Port 33434 is the IANA-reserved port for traceroute. It also seems to be
the most common start port. The following implementations, and
likely others, use it as their start port:

- Apple macOS traceroute
- FreeBSD traceroute
- GNU inetutils-traceroute
- Modern traceroute for Linux
- OpenBSD traceroute

The benefit to using a standard starting port is that some firewalls may
have these ports allowed, whereas other ports may be blocked, so there
is a greater probability the probe will succeed.

I’m uncertain if the `SEQUENCE_NUM` and `MinSequence` constants should also be changed.