### PR TITLE
use addrs for static host ordering in curses

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -421,8 +421,8 @@ static void mtr_curses_hosts(
     for (at = net_min(ctl) + ctl->display_offset; at < max; at++) {
         printw("%2d. ", at + 1);
         err = net_err(at);
-        addr = net_addr(at);
-        mpls = net_mpls(at);
+        addr = net_addrs(at, 0);
+        mpls = net_mplss(at, 0);
 
         addrcmp_result = addrcmp(addr, &ctl->unspec_addr, ctl->af);
 
@@ -471,7 +471,7 @@ static void mtr_curses_hosts(
             }
 
             /* Multi path */
-            for (i = 0; i < MAX_PATH; i++) {
+            for (i = 1; i < MAX_PATH; i++) {
                 addrs = net_addrs(at, i);
                 mplss = net_mplss(at, i);
                 if (addrcmp(addrs, addr, ctl->af) == 0)


### PR DESCRIPTION
Change d2552ca has the side effect of moving hosts around in the
multipath view, as the last host to reply to a packet was set as
addr.  Using addrs[0] istead of addr to draw the first host keeps
the ordering deterministic, in order of first reply.