### PR TITLE
add --max-display-paths option

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -92,6 +92,9 @@ mtr \- a network diagnostic tool
 .BI \-U \ MAX\-UNKNOWN\c
 ]
 [\c
+.BI \-E \ MAX\-DISPLAY\-PATH\c
+]
+[\c
 .B \-\-udp\c
 ]
 [\c
@@ -406,6 +409,9 @@ probe.  Default is 30.
 .TP
 .B \-U \fINUM\fR, \fB\-\-max-unknown \fINUM
 Specifies the maximum unknown host. Default is 5.
+.TP
+.B \-E \fINUM\fR, \fB\-\-max-display-path \fINUM
+Specifies the maximum number of ECMP paths to display. Default is 8.
 .TP
 .B \-u\fR, \fB\-\-udp
 Use UDP datagrams instead of ICMP ECHO.

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -471,7 +471,7 @@ static void mtr_curses_hosts(
             }
 
             /* Multi path */
-            for (i = 1; i < MAX_PATH; i++) {
+            for (i = 1; i < ctl->maxDisplayPath; i++) {
                 addrs = net_addrs(at, i);
                 mplss = net_mplss(at, i);
                 if (addrcmp(addrs, addr, ctl->af) == 0)

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -369,6 +369,7 @@ static void parse_arg(
         {"first-ttl", 1, NULL, 'f'},    /* -f & -m are borrowed from traceroute */
         {"max-ttl", 1, NULL, 'm'},
         {"max-unknown", 1, NULL, 'U'},
+        {"max-display-path", 1, NULL, 'E'},
         {"udp", 0, NULL, 'u'},  /* UDP (default is ICMP) */
         {"tcp", 0, NULL, 'T'},  /* TCP (default is ICMP) */
 #ifdef HAS_SCTP
@@ -519,6 +520,12 @@ static void parse_arg(
                 strtonum_or_err(optarg, "invalid argument", STRTO_INT);
             if (ctl->maxUnknown < 1) {
                 ctl->maxUnknown = 1;
+            }
+            break;
+        case 'E':
+            ctl->maxDisplayPath = strtonum_or_err(optarg, "invalid argument", STRTO_INT);
+            if (ctl->maxDisplayPath > MAX_PATH) {
+                ctl->maxDisplayPath = MAX_PATH;
             }
             break;
         case 'o':
@@ -747,6 +754,7 @@ int main(
     ctl.fstTTL = 1;
     ctl.maxTTL = 30;
     ctl.maxUnknown = 12;
+    ctl.maxDisplayPath = 8;
     ctl.probe_timeout = 10 * 1000000;
     ctl.ipinfo_no = -1;
     ctl.ipinfo_max = -1;

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -64,7 +64,7 @@ typedef int time_t;
 
 /* net related definitions */
 #define SAVED_PINGS 200
-#define MAX_PATH 8
+#define MAX_PATH 128
 #define MaxHost 256
 #define MinPort 1024
 #define MaxPort 65535
@@ -103,6 +103,7 @@ struct mtr_ctl {
     int fstTTL;                 /* initial hub(ttl) to ping byMin */
     int maxTTL;                 /* last hub to ping byMin */
     int maxUnknown;             /* stop ping threshold */
+    int maxDisplayPath;         /* maximum number of ECMP paths to display */
     int remoteport;             /* target port for TCP tracing */
     int localport;              /* source port for UDP tracing */
     int probe_timeout;          /* timeout for probe sockets */

--- a/ui/report.c
+++ b/ui/report.c
@@ -185,7 +185,7 @@ void report_close(
         /* This feature shows 'loadbalances' on routes */
 
         /* Print list of all hosts that have responded from ttl = at + 1 away */
-        for (z = 0; z < MAX_PATH; z++) {
+        for (z = 0; z < ctl->maxDisplayPath; z++) {
             int found = 0;
             addr2 = net_addrs(at, z);
             mplss = net_mplss(at, z);
@@ -531,7 +531,7 @@ void csv_close(
         if (ctl->reportwide == 0)
             continue;
         
-        for (z = 0; z < MAX_PATH; z++) {
+        for (z = 0; z < ctl->maxDisplayPath; z++) {
             int found = 0;
             addr2 = net_addrs(at, z);
             snprint_addr(ctl, name, sizeof(name), addr2);


### PR DESCRIPTION
It is not unknown to have datacenters with over 8 ECMP paths between two
hops.  Expand the maximum number of ECMP hosts stored in addrs to 128,
and add a new option to control the number to display, defaulting to the
old MAX_PATHS of 8