### PR TITLE
Set SO_BINDTODEVICE for `-I`

### DIFF
--- a/packet/command.c
+++ b/packet/command.c
@@ -189,6 +189,11 @@ bool decode_probe_argument(
         param->local_address = value;
     }
 
+    /*  Device name to send from  */
+    if (!strcmp(name, "local-device")) {
+        param->local_device = value;
+    }
+
     /*  Protocol for the probe  */
     if (!strcmp(name, "protocol")) {
         if (!strcmp(value, "icmp")) {

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -398,6 +398,13 @@ int set_stream_socket_options(
     }
 #endif
 
+    if (param->local_device) {
+        if (setsockopt(stream_socket, SOL_SOCKET,
+                       SO_BINDTODEVICE, param->local_device, strlen(param->local_device))) {
+            return -1;
+        }
+    }
+
     return 0;
 }
 
@@ -614,6 +621,13 @@ int construct_ip4_packet(
     }
 #endif
 
+    if (param->local_device) {
+        if (setsockopt(send_socket, SOL_SOCKET,
+                       SO_BINDTODEVICE, param->local_device, strlen(param->local_device))) {
+            return -1;
+        }
+    }
+
     /*
        Bind src port when not using raw socket to pass in ICMP id, kernel
        get ICMP id from src_port when using DGRAM socket.
@@ -781,6 +795,14 @@ int construct_ip6_packet(
         }
     }
 #endif
+
+    if (param->local_device) {
+        if (setsockopt(send_socket,
+                       SOL_SOCKET, SO_BINDTODEVICE, param->local_device,
+                       strlen(param->local_device))) {
+            return -1;
+        }
+    }
 
     return 0;
 }

--- a/packet/probe.h
+++ b/packet/probe.h
@@ -53,6 +53,9 @@ struct probe_param_t {
     /*  The local address from which to send probes  */
     const char *local_address;
 
+    /*  The local device from which to send probes  */
+    const char *local_device;
+
     /*  Protocol for the probe, using the IPPROTO_* defines  */
     int protocol;
 

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -417,6 +417,22 @@ void append_command_argument(
     strncat(command, argument, remaining_size);
 }
 
+static
+void append_command_string_argument(
+    char *command,
+    int buffer_size,
+    char *name,
+    char *value)
+{
+    char argument[COMMAND_BUFFER_SIZE];
+    int remaining_size;
+
+    remaining_size = buffer_size - strlen(command) - 1;
+
+    snprintf(argument, buffer_size, " %s %s", name, value);
+    strncat(command, argument, remaining_size);
+}
+
 
 /*  Request a new probe from the "mtr-packet" child process  */
 void send_probe_command(
@@ -465,6 +481,11 @@ void send_probe_command(
                                 ctl->mark);
     }
 #endif
+
+    if (ctl->InterfaceName) {
+        append_command_string_argument(command, COMMAND_BUFFER_SIZE,
+                                       "local-device", ctl->InterfaceName);
+    }
 
     remaining_size = COMMAND_BUFFER_SIZE - strlen(command) - 1;
     strncat(command, "\n", remaining_size);


### PR DESCRIPTION
This is done by traceroute and other tools as well. It requires CAP_NET_RAW, but without it the `-I` option doesn't seem to have any effect.

I could only test with IPv4, but it worked fine for ICMP, TCP and UDP. Not sure if additional handling is required for the case where CAP_NET_RAW isn't available it shows "Unexpected mtr-packet error" like it does for `-M`. Before this change there was no error, but it didn't take the interface into account.

Could be relevant for #379, #250, #232, although it doesn't handle the `-a` option. This is comparable to `traceroute` though. `traceroute -s <IP>`  shows the same (wrong?) hops as `mtr -a <IP>` after this change, while `traceroute -i <NAME>` shows the same (correct) hops as `mtr -I <NAME>`. So I'd argue that this is the correct behavior.