### PR TITLE
ui: make interactive and non-interactive exit code the same

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -710,6 +710,7 @@ int main(
     int argc,
     char **argv)
 {
+    int exit_val = EXIT_SUCCESS;
     names_t *names_head = NULL;
     names_t *names_walk;
 
@@ -784,6 +785,7 @@ int main(
             if (ctl.Interactive)
                 exit(EXIT_FAILURE);
             else {
+                exit_val = EXIT_FAILURE;
                 names_walk = names_walk->next;
                 continue;
             }
@@ -794,6 +796,7 @@ int main(
             if (ctl.Interactive)
                 exit(EXIT_FAILURE);
             else {
+                exit_val = EXIT_FAILURE;
                 names_walk = names_walk->next;
                 continue;
             }
@@ -829,5 +832,5 @@ int main(
         item = NULL;
     }
 
-    return 0;
+    return exit_val;
 }


### PR DESCRIPTION
Before this change the report gave successful exit value when destination
hostname could not be found.

    $ ./mtr --report nxdomain. ; echo $?
    ./mtr: Failed to resolve host: nxdomain.: Name or service not known
    0

Quickly looking 'git grep ---after-context if.*Interactive' there does not
appear to be more than the two instances in main() where exit is called
depending on interactive, so this change should cover all these cases.

Reported-by: Marek Kroemeke <mkroemeke@cloudflare.com>
Signed-off-by: Sami Kerola <kerolasa@iki.fi>