### PR TITLE
Allow using all UDP ports

### DIFF
--- a/packet/command.c
+++ b/packet/command.c
@@ -225,15 +225,6 @@ bool decode_probe_argument(
         if (*endstr != 0) {
             return false;
         }
-
-        /*
-           Don't allow using a local port which requires
-           privileged binding.
-         */
-        if (param->local_port < 1024) {
-            param->local_port = 0;
-            return false;
-        }
     }
 
     /*  The "type of service" field for the IP header  */

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -580,7 +580,7 @@ static void parse_arg(
         case 'L':
             ctl->localport =
                 strtonum_or_err(optarg, "invalid argument", STRTO_INT);
-            if (ctl->localport < MinPort || MaxPort < ctl->localport) {
+            if (MaxPort < ctl->localport) {
                 error(EXIT_FAILURE, 0, "Illegal port number: %d",
                       ctl->localport);
             }

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -66,7 +66,6 @@ typedef int time_t;
 #define SAVED_PINGS 200
 #define MAX_PATH 128
 #define MaxHost 256
-#define MinPort 1024
 #define MaxPort 65535
 #define MAXPACKET 4470          /* largest test packet size */
 #define MINPACKET 28            /* 20 bytes IP header and 8 bytes ICMP or UDP */


### PR DESCRIPTION
As #421 explains, this is incredibly useful and running mtr as root for this is a cost worth paying. I removed the entire logic to also allow port 0 as Wikipedia states:
> while for UDP, the source port is optional and a value of zero means
no port

Closes #421