### PR TITLE
Github actions added to perform lint and compile

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,14 @@
+[flake8]
+
+select =
+    E902,
+    E999,
+    S,
+    F,
+
+ignore =
+    F821
+
+per-file-ignores =
+    test/*: S603,S404
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,35 @@
+name: Test compilation
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install flake8
+        run: pip3 install flake8==3.9.2 flake8-bandit==2.1.2 bandit==1.7.2
+      - name: Run flake8
+        run: python3 -m flake8 .
+  compile-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - uses: egor-tensin/setup-gcc@v1.3
+        with:
+          version: latest
+          platform: x64
+      - name: Bootstrap
+        run: ./bootstrap.sh
+      - name: Configure
+        run: ./configure --without-gtk --without-jansson
+      - name: Make
+        run: make -j $(nproc)
+      - name: Run sample mtr against 1.1.1.1
+        run: ./mtr --report --report-cycles 1 -m 1 1.1.1.1
+      - name: Run test - cmdparse.py
+        run: python3 ./test/cmdparse.py

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ stamp-h1*
 /test/*.py.trs
 
 /mtr-*.tar.gz
+*.swp

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ m4_ifndef([PKG_CHECK_MODULES], [m4_defun([PKG_CHECK_MODULES], [AC_MSG_ERROR(
 [Could not locate the pkg-config autoconf macros.  These are usually located
 in /usr/share/aclocal/pkg.m4.  If your macros are in a different location,
 try setting the environment variable ACLOCAL_OPTS="-I/other/macro/dir"
-before running ./bootstrap.sh again, or configure --without-gtk ----without-jansson ])])
+before running ./bootstrap.sh again, or configure --without-gtk --without-jansson ])])
 ])
 PKG_PROG_PKG_CONFIG
 

--- a/test/probe.py
+++ b/test/probe.py
@@ -263,7 +263,6 @@ class TestProbeICMPv4(mtrpacket.MtrPacketTest):
         required_success = int(loop_count * 0.90)
         self.assertGreaterEqual(success_count, required_success)
 
-
 class TestProbeICMPv6(mtrpacket.MtrPacketTest):
     '''Test sending probes using IP version 6'''
 


### PR DESCRIPTION
In the test folder, there was lint.sh, but I think flake8 is a better tool. When this PR is reviewed, let's discuss if we can use flake8  in which case I can remove lint.sh.

Added a compile job for linux, this runs compilation as defined in the README, runs a sample mtr to 1.1.1.1 and runs cmdparse.py test. Need documentation on what other tests to run and whether to include the testing in tox instead of running them individually.

Not adding in this PR support for cygwin, macos, or freebsd, as that will need investigation on how to run.

Minor:
- Fixed a typo in configure.ac that used 4 dashes vs 2 for a flag option.

Actions will run when this gets merged in.

The actions ran in my fork from this commit: [MTR github actions run](https://github.com/darless/mtr/actions/runs/5523401612)

Items to discuss in PR prior to merge
- [ ] Within the test directory there is lint.sh which uses pylint. I think flake8 is a better tool and this commit uses that. If this is sufficient, then lint.sh can be removed/modified to use flake8. 
- [ ] Discuss plans for testing, currently a very limited test is done, but we could add cygwin, mac, tests as needed (I would think separate issues for those to add on to the testing. This is only a base testing PR