### PR TITLE
Adjust capability handling

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -294,21 +294,19 @@ int construct_udp6_packet(
 typedef cap_value_t mayadd_cap_value_t;
 #define MAYADD_CAP_NET_RAW CAP_NET_RAW
 #define MAYADD_CAP_NET_ADMIN CAP_NET_ADMIN
-#define MAYADD_UNUSED
 
 #else /* ifdef HAVE_LIBCAP */
 
 typedef int mayadd_cap_value_t;
 #define MAYADD_CAP_NET_RAW ((mayadd_cap_value_t) 0)
 #define MAYADD_CAP_NET_ADMIN ((mayadd_cap_value_t) 0)
-#define MAYADD_UNUSED UNUSED
 
 #endif /* ifdef HAVE_LIBCAP */
 
-static
+UNUSED static
 int set_privileged_socket_opt(int socket, int option_name,
     void const * option_value, socklen_t option_len,
-    MAYADD_UNUSED mayadd_cap_value_t required_cap) {
+    UNUSED mayadd_cap_value_t required_cap) {
 
     int result = -1;
 

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -331,12 +331,10 @@ int set_privileged_socket_opt(int socket, int option_name,
     if (cap_set_proc(cap)) {
         goto cleanup_and_exit;
     }
-#endif /* ifdef HAVE_LIBPCAP */
+#endif /* ifdef HAVE_LIBCAP */
 
     // Set the socket mark
-    if (setsockopt(socket, SOL_SOCKET, option_name, option_value, option_len)) {
-        goto cleanup_and_exit;
-    }
+    int set_sock_err = setsockopt(socket, SOL_SOCKET, option_name, option_value, option_len);
 
     // Drop CAP_NET_ADMIN from the effective set if libcap is present
 #ifdef HAVE_LIBCAP
@@ -351,15 +349,16 @@ int set_privileged_socket_opt(int socket, int option_name,
     if (cap_set_proc(cap)) {
         goto cleanup_and_exit;
     }
-#endif /* ifdef HAVE_LIBPCAP */
+#endif /* ifdef HAVE_LIBCAP */
 
-    result = 0; // Success
-
-cleanup_and_exit:
+    if(!set_sock_err) {
+        result = 0; // Success
+    }
 
 #ifdef HAVE_LIBCAP
+cleanup_and_exit:
     cap_free(cap);
-#endif /* ifdef HAVE_LIBPCAP */
+#endif /* ifdef HAVE_LIBCAP */
 
     return result;
 }

--- a/packet/utils.h
+++ b/packet/utils.h
@@ -1,0 +1,14 @@
+#ifndef _UTILS_H
+#define _UTILS_H
+
+// Fend off -Wunused-parameter
+#if defined(__GNUC__)
+# define UNUSED __attribute__((__unused__))
+#else
+# define UNUSED
+#endif
+
+// Number of entries in a fixed-length array
+#define N_ENTRIES(x) (sizeof(x) / sizeof(*x))
+
+#endif


### PR DESCRIPTION
This PR addresses issues related to capability handling in `mtr-packet`, as detailed in issue #485. It completely resolves Bug 1 and partially resolves Bug 2 by ensuring that `CAP_NET_RAW` and `CAP_NET_ADMIN` are retained in the permitted set. These capabilities are elevated to the effective set when necessary. This eliminates "permission denied" errors encountered when specifying a local interface using the `--interface` flag or setting a packet mark with the `-M` option. To the best of my knowledge, these issues are specific to Linux.

The commits have been tested on Linux version 6.1.51.