### PR TITLE
Set mark during address selection

### DIFF
--- a/packet/probe.h
+++ b/packet/probe.h
@@ -69,7 +69,7 @@ struct probe_param_t {
     int type_of_service;
 
     /*  The packet "mark" used for mark-based routing on Linux  */
-    int routing_mark;
+    uint32_t routing_mark;
 
     /*  Time to live for the transmitted probe  */
     int ttl;

--- a/ui/utils.c
+++ b/ui/utils.c
@@ -80,7 +80,7 @@ int strtonum_or_err(
 
     if (str != NULL && *str != '\0') {
         errno = 0;
-        num = strtoul(str, &end, 10);
+        num = strtoul(str, &end, 0);
         if (errno == 0 && str != end && end != NULL && *end == '\0') {
             switch (type) {
             case STRTO_INT:


### PR DESCRIPTION
This PR addresses and resolves issue #485 concerning address selection when using a packet mark. While I believe there's a more "correct" way to fix this issue, the solution would require extensive changes that I currently do not have the time to implement.

This PR tackles the most prevalent variant of the issue. I plan to create a new issue outlining my ideal approach for resolving this problem. This will serve as a guide for anyone who might revisit the issue in the future, offering one potential solution and outlining the limitations of the current patch.

## Changes

- The patch makes minimal alterations, fixing the issue by setting the mark during the address selection process.
- This fix only addresses the problem in `mtr` and not in `mtr-packet`.
- The patch also adds support for parsing packet marks as hex values, which is a common way to refer to packet marks.

## Testing

I tested these patches on Linux 6.1 and FreeBSD 13.2. As the changes only involve packet marking, they do not affect non-Linux operating systems. Therefore, FreeBSD can be used as a stand-in for NetBSD or Solaris.

### Testing Steps:

#### Linux

I have a routing table with a unique default gateway corresponding to mark `2088138254`. I tested the application both with and without the mark to ensure that it traced the correct path. `mtr` performed as expected in both scenarios.

```bash
make clean
make
MTR_PACKET="./mtr-packet" sudo -E ./mtr -t 1.1.1.1 # traces the expected route
MTR_PACKET="./mtr-packet" sudo -E ./mtr -t -M 2088138254 1.1.1.1 # traces the expected route
MTR_PACKET="./mtr-packet" sudo -E ./mtr -t -M 0x7c76760e 1.1.1.1 # traces the expected route
```

#### BSD

As FreeBSD does not support routing marks, my test on this OS involved merely compiling `mtr` and confirming that it could trace a route, thereby triggering the address selection logic.

```bash
make clean
make
MTR_PACKET="./mtr-packet" sudo -E ./mtr 1.1.1.1 # traces the expected route
MTR_PACKET="./mtr-packet" sudo -E ./mtr -I vtnet0 1.1.1.1 # traces the expected route
```