### PR TITLE
Fix warning

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -175,7 +175,7 @@ void set_udp_ports(
 
 /* Prepend pseudoheader to the udp datagram and calculate checksum */
 static
-int udp4_checksum(void *pheader, void *udata, int psize, int dsize,
+int udp_checksum(void *pheader, void *udata, int psize, int dsize,
                   int alt_checksum)
 {
     unsigned int totalsize = psize + dsize;
@@ -234,7 +234,7 @@ int construct_udp4_packet(
                                                   udp_size +
                                                   sizeof(struct UDPHeader)];
     }
-    *checksum_off = htons(udp4_checksum(&udph, udp,
+    *checksum_off = htons(udp_checksum(&udph, udp,
                                         sizeof(struct UDPPseudoHeader),
                                         udp_size, udp->checksum != 0));
 
@@ -276,7 +276,7 @@ int construct_udp6_packet(
          checksum_off is udp payload */
         checksum_off = (uint16_t *)&packet_buffer[sizeof(struct UDPHeader)];
     }
-    *checksum_off = htons(udp4_checksum(&udph, udp,
+    *checksum_off = htons(udp_checksum(&udph, udp,
                                         sizeof(struct IP6PseudoHeader),
                                         udp_size, udp->checksum != 0));
     return 0;

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -244,13 +244,11 @@ int construct_udp4_packet(
 /*  Construct a header for UDPv6 probes  */
 static
 int construct_udp6_packet(
-    const struct net_state_t *net_state,
     struct probe_t *probe,
     char *packet_buffer,
     int packet_size,
     const struct probe_param_t *param)
 {
-    int udp_socket = net_state->platform.udp6_send_socket;
     struct UDPHeader *udp;
     int udp_size;
 
@@ -782,7 +780,7 @@ int construct_ip6_packet(
         }
 
         if (construct_udp6_packet
-            (net_state, probe, packet_buffer, packet_size, param)) {
+            (probe, packet_buffer, packet_size, param)) {
             return -1;
         }
     } else {


### PR DESCRIPTION
This fixes an "unused variable" warning printed during compilation on 13.2.1.

Tested on Linux and FreeBSD wtih:

```
make clean
make
MTR_PACKET="./mtr-packet" sudo -E ./mtr -t --udp 2606:4700:4700::1111
```