### PR TITLE
Add a compact mode in curses

### DIFF
--- a/ui/display.h
+++ b/ui/display.h
@@ -20,7 +20,7 @@
 
 /* Don't put a trailing comma in enumeration lists. Some compilers
    (notably the one on Irix 5.2) do not like that. */
-enum { ActionNone, ActionQuit, ActionReset, ActionDisplay,
+enum { ActionNone, ActionQuit, ActionReset, ActionDisplay, ActionCompact,
     ActionClear, ActionPause, ActionResume, ActionMPLS, ActionDNS,
 #ifdef HAVE_IPINFO
     ActionII, ActionAS,

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -116,7 +116,7 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5;
+        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
 };
 
 /* dynamic field drawing */

--- a/ui/select.c
+++ b/ui/select.c
@@ -224,6 +224,10 @@ void select_loop(
                 ctl->display_mode =
                     (ctl->display_mode + 1) % DisplayModeMAX;
                 break;
+            case ActionCompact:
+                ctl->CompactLayout = !ctl->CompactLayout;
+                display_clear(ctl);
+                break;
             case ActionClear:
                 display_clear(ctl);
                 break;


### PR DESCRIPTION
Saves 5 lines of screen space in curses when 'c' is pressed. 