### PR TITLE
Handle EHOSTDOWN and refine error handling better granularity

### DIFF
--- a/man/mtr-packet.8.in
+++ b/man/mtr-packet.8.in
@@ -317,13 +317,17 @@ label, and so on.  The values are provided in this order:
 .IR ttl .
 .HP 7
 .TP
-.B no-route
-There was no route to the host used in a
+.B no-route-network
+.B no-route-host
+There was no route to the network or the host itself for the
 .B send-probe
-request.
+request used to reach the host.
 .TP
 .B network-down
 A probe could not be sent because the network is down.
+.TP
+.B host-down
+A probe could not be sent because the host is down.
 .TP
 .B probes-exhausted
 A probe could not be sent because there are already too many unresolved

--- a/packet/probe.c
+++ b/packet/probe.c
@@ -264,7 +264,8 @@ void respond_to_probe(
     if (icmp_type == ICMP_TIME_EXCEEDED) {
         result = "ttl-expired";
     } else if (icmp_type == ICMP_DEST_UNREACH) {
-        result = "no-route";
+        /* XXX icmphdr->code is not known here, so assume that host is unreachable */
+        result = "no-route-host";
     } else {
         assert(icmp_type == ICMP_ECHOREPLY);
         result = "reply";

--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -534,10 +534,12 @@ void report_packet_error(
         printf("%d invalid-argument\n", command_token);
     } else if (errno == ENETDOWN) {
         printf("%d network-down\n", command_token);
+    } else if (errno == EHOSTDOWN) {
+        printf("%d host-down\n", command_token);
     } else if (errno == ENETUNREACH) {
-        printf("%d no-route\n", command_token);
+        printf("%d no-route-network\n", command_token);
     } else if (errno == EHOSTUNREACH) {
-        printf("%d no-route\n", command_token);
+        printf("%d no-route-host\n", command_token);
     } else if (errno == EPERM) {
         printf("%d permission-denied\n", command_token);
     } else if (errno == EADDRINUSE) {

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -715,10 +715,14 @@ void handle_command_reply(
     if (!strcmp(reply_name, "reply")
             || !strcmp(reply_name, "ttl-expired")) {
         err = 0;
-    } else if (!strcmp(reply_name, "no-route")) {
-        err = ENETUNREACH;
     } else if (!strcmp(reply_name, "network-down")) {
         err = ENETDOWN;
+    } else if (!strcmp(reply_name, "host-down")) {
+        err = EHOSTDOWN;
+    } else if (!strcmp(reply_name, "no-route-network")) {
+        err = ENETUNREACH;
+    } else if (!strcmp(reply_name, "no-route-host")) {
+        err = EHOSTUNREACH;
     } else {
         /*  If the reply type is unknown, ignore it  */
         return;

--- a/ui/display.c
+++ b/ui/display.c
@@ -266,17 +266,16 @@ void display_clear(
 char *host_error_to_string(
     int err)
 {
-    if (err == ENETUNREACH) {
+    if (err == ENETDOWN)
+        return "network is down";
+    else if (err == EHOSTDOWN)
+        return "host is down";
+    else if (err == ENETUNREACH)
+        return "no route to network";
+    else if (err == EHOSTUNREACH)
         return "no route to host";
-    }
-
-    if (err == ENETDOWN) {
-        return "network down";
-    }
-
-    if (err == 0) {
+    else if (err == 0)
         return "waiting for reply";
-    }
 
     return strerror(err);
 }


### PR DESCRIPTION
Handle EHOSTDOWN which occurs on MacOS and causes:

% mtr 192.168.68.2
mtr: Unexpected mtr-packet error

for unreachable host and also split error handling better granularity.