### PR TITLE
Remove redundant code

### DIFF
--- a/ui/utils.c
+++ b/ui/utils.c
@@ -80,7 +80,7 @@ int strtoint_or_err(
     if (str != NULL && *str != '\0') {
         errno = 0;
         num = strtol(str, &end, 0);
-        if (errno == 0 && str != end && end != NULL && *end == '\0' && num < INT_MAX) {
+        if (errno == 0 && str != end && end != NULL && *end == '\0') {
             return num;
         }
     }
@@ -99,7 +99,7 @@ unsigned long strtoulong_or_err(
     if (str != NULL && *str != '\0') {
         errno = 0;
         num = strtoul(str, &end, 0);
-        if (errno == 0 && str != end && end != NULL && *end == '\0' && num < UINT32_MAX) {
+        if (errno == 0 && str != end && end != NULL && *end == '\0') {
             return num;
         }
     }


### PR DESCRIPTION
As @yvs2014 noted in https://github.com/traviscross/mtr/issues/523#issuecomment-2660970185, it is unnecessary to check whether an int is larger than the maximum int value. An int cannot be greater than the maximum int value.

Follows https://github.com/traviscross/mtr/pull/525