### PR TITLE
Fix https://github.com/traviscross/mtr/issues/475

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -202,7 +202,10 @@ int mtr_curses_keyaction(
             buf[i++] = c;       /* need more checking on 'c' */
         }
         buf[i] = '\0';
-        ctl->cpacketsize = atoi(buf);
+        int new_packetsize = atoi(buf);
+        if (abs(ctl->cpacketsize) >= MINPACKET && abs(ctl->cpacketsize) < MAXPACKET) {
+            ctl->cpacketsize = new_packetsize;
+        }
         return ActionNone;
     case 'b':
         mvprintw(2, 0, "Ping Bit Pattern: %d\n", ctl->bitpattern);

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -452,6 +452,9 @@ static void parse_arg(
         case 's':
             ctl->cpacketsize =
                 strtoint_or_err(optarg, "invalid argument");
+            if (abs(ctl->cpacketsize) < MINPACKET || abs(ctl->cpacketsize) > MAXPACKET) {
+                error(EXIT_FAILURE, 0, "value of of range (%d - %d)", MINPACKET, MAXPACKET);
+            }
             break;
         case 'I':
             ctl->InterfaceName = optarg;

--- a/ui/net.c
+++ b/ui/net.c
@@ -561,8 +561,13 @@ int net_send_batch(
                smaller (reasonable packet sizes), and our rand() range much
                larger, this effect is insignificant. Oh! That other formula
                didn't work. */
-            packetsize =
-                MINPACKET + rand() % (-ctl->cpacketsize - MINPACKET);
+            if (-ctl->cpacketsize <= MINPACKET) {
+                /* There is no room to introduce randomness. */
+                packetsize = MINPACKET;
+            } else {
+                packetsize =
+                    MINPACKET + rand() % (-ctl->cpacketsize - MINPACKET);
+            }
         } else {
             packetsize = ctl->cpacketsize;
         }


### PR DESCRIPTION
With an input of `-28` the expression `(-ctl->cpacketsize - MINPACKET)` became 0, which triggered a zero division. This error is fixed by introducing a check to see if there is any room for randomness. Furthermore, a check of the input arguments in the command line and in curses is performed.
MINPACKET assumes IPv4, so these checks do not apply to IPv6. mtr still seems to work with IPv6, so it is likely that there is an additional check elsewhere.
I think it's still okay to assume IPv4 for MINPACKET (the minimum size of a packet), since IPv4 packets are smaller than IPv6 packets (due to the IP header).