### PR TITLE
mtr braille graph support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,20 @@ AS_IF([test "x$with_jansson" = "xyes"],
     [with_jansson=no])
 ])
 
+# Find ncursesw
+AC_ARG_WITH([ncursesw],
+  [AS_HELP_STRING([--without-ncursesw], [Build without the ncursesw interface])],
+  [], [with_ncursesw=yes])
+AS_IF([test "x$with_ncursesw" = "xyes"],
+
+  # Prefer ncursesw, if available
+  [AC_SEARCH_LIBS(
+    [wprintw], [ncursesw],
+    [AC_DEFINE([HAVE_CURSESW], [1], [Define if a ncursesw library available])],
+    [with_ncursesw=no])
+])
+AM_CONDITIONAL([WITH_CURSESW], [test "x$with_ncursesw" = xyes])
+
 # Find ncurses
 AC_ARG_WITH([ncurses],
   [AS_HELP_STRING([--without-ncurses], [Build without the ncurses interface])],
@@ -121,7 +135,7 @@ AS_IF([test "x$with_ncurses" = "xyes"],
   # Prefer ncurses over curses, if both are available.
   # (On Solaris 11.3, ncurses builds and links for us, but curses does not.)
   [AC_SEARCH_LIBS(
-    [initscr], [ncurses curses],
+    [initscr], [ncursesw ncurses curses],
     [AC_DEFINE([HAVE_CURSES], [1], [Define if a curses library available])],
     [with_ncurses=no])
 ])
@@ -151,6 +165,15 @@ AC_ARG_ENABLE([ipv6],
 AS_IF([test "x$WANTS_IPV6" = "xyes"], [
   AC_DEFINE([ENABLE_IPV6], [1], [Define to enable IPv6])
   USES_IPV6=yes
+])
+
+AC_ARG_ENABLE([braille],
+  [AS_HELP_STRING([--disable-braille], [Do not enable barille character graphs])],
+  [WANTS_BRAILLE=$enableval], [WANTS_BRAILLE=yes])
+
+AS_IF([test "x$WANTS_BRAILLE" = "xyes"], [
+  AC_DEFINE([ENABLE_BRAILLE], [1], [Define to enable IPv6])
+  USES_BRAILLE=yes
 ])
 
 AC_CHECK_FUNC([socket], [],
@@ -266,15 +289,17 @@ AC_ARG_ENABLE([bash-completion],
 AM_CONDITIONAL([BUILD_BASH_COMPLETION], [test "x$enable_bash_completion" = xyes])
 echo "build options:"
 echo "--------------"
-echo "libasan :$with_libasan"
-echo "ipv6    :$USES_IPV6"
-echo "ipinfo  :$with_ipinfo"
-echo "ncurses :$with_ncurses"
-echo "gtk     :$with_gtk"
-echo "jansson :$with_jansson"
-echo "cap     :$have_cap"
-echo "libs    :$LIBS"
-echo "cflags  :$CFLAGS"
+echo "libasan  :$with_libasan"
+echo "ipv6     :$USES_IPV6"
+echo "braille  :$USES_BRAILLE"
+echo "ipinfo   :$with_ipinfo"
+echo "ncursesw :$with_ncursesw"
+echo "ncurses  :$with_ncurses"
+echo "gtk      :$with_gtk"
+echo "jansson  :$with_jansson"
+echo "cap      :$have_cap"
+echo "libs     :$LIBS"
+echo "cflags   :$CFLAGS"
 echo "--------------"
 # Prepare config.h, Makefile, and output them.
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ AC_ARG_ENABLE([braille],
   [WANTS_BRAILLE=$enableval], [WANTS_BRAILLE=yes])
 
 AS_IF([test "x$WANTS_BRAILLE" = "xyes"], [
-  AC_DEFINE([ENABLE_BRAILLE], [1], [Define to enable IPv6])
+  AC_DEFINE([ENABLE_BRAILLE], [1], [Define to enable uncode braille character graphs])
   USES_BRAILLE=yes
 ])
 

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -71,6 +71,11 @@ enum { NUM_FACTORS = 8 };
 static double factors[NUM_FACTORS];
 static int scale[NUM_FACTORS];
 static char block_map[NUM_FACTORS];
+#ifdef WITH_BRAILLE_DISPLAY
+static const wchar_t *braille_map[NUM_FACTORS] = {
+    L"⣀", L"⣀", L"⣤", L"⣤", L"⣶", L"⣶", L"⣿", L"🮐"
+};
+#endif
 
 enum { black = 1, red, green, yellow, blue, magenta, cyan, white };
 static const int block_col[NUM_FACTORS + 1] = {
@@ -952,17 +957,23 @@ void mtr_curses_redraw(
         printw("Scale:");
         attroff(A_BOLD);
 
-        for (i = 0; i < NUM_FACTORS - 1; i++) {
+#ifdef WITH_BRAILLE_DISPLAY
+        bool use_braille_map = (ctl->display_mode == DisplayModeBraille);
+#endif
+
+        for (i = 0; i < NUM_FACTORS; i++) {
             printw("  ");
             attrset(block_col[i + 1]);
-            printw("%c", block_map[i]);
+#ifdef WITH_BRAILLE_DISPLAY
+            if (use_braille_map)
+                printw("%ls", braille_map[i]);
+            else
+#endif
+                printw("%c", block_map[i]);
             attrset(A_NORMAL);
-            printw(":%d ms", scale[i] / 1000);
+            if (i < NUM_FACTORS-1)
+                printw(":%d ms", scale[i] / 1000);
         }
-        printw("  ");
-        attrset(block_col[NUM_FACTORS]);
-        printw("%c", block_map[NUM_FACTORS - 1]);
-        attrset(A_NORMAL);
     }
 
     refresh();

--- a/ui/display.h
+++ b/ui/display.h
@@ -46,10 +46,18 @@ enum {
 #endif
 };
 
+// if we have libncursesw and braille graphs were enabled, build with them
+#if HAVE_CURSESW && ENABLE_BRAILLE
+#define WITH_BRAILLE_DISPLAY 1
+#endif
+
 enum {
     DisplayModeDefault,
     DisplayModeBlockmap,
     DisplayModeBlockmapScale,
+#ifdef WITH_BRAILLE_DISPLAY
+    DisplayModeBraille,
+#endif
     DisplayModeMAX              /* this must be the last DisplayMode entry */
 };
 

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -63,7 +63,7 @@ typedef int time_t;
 #define FLD_INDEX_SZ 256
 
 /* net related definitions */
-#define SAVED_PINGS 200
+#define SAVED_PINGS 400
 #define MAX_PATH 128
 #define MaxHost 256
 #define MinPort 1024


### PR DESCRIPTION
This PR adds support for `--displaymode 3` which renders a graph using unicode braille characters.

![image](https://github.com/user-attachments/assets/df4e53dd-0773-479c-bcd8-c8742ca28e0b)


Changes include:
* modify autoconf to detect `libncursesw` for wide char support
* only build `WITH_BRAILLE_DISPLAY` when wide support is detected
* since braille chars can show 2x the information, increases `SAVED_PINGS` to 400
* added `DisplayModeBraille` which allows setting `--displaymode 3`
* all rendering changes are in `ui/curses.c`
* with `DisplayModeBraille` selected, `mtr_curses_graph` will call `mtr_fill_graph_braille` instead of `mtr_fill_graph`
* braille characters can render 4 levels of dots, but I found that I could only use 3 to avoid lines bleeding into one another, while the bottom row becomes the origin line
* for each host, the values collected are scaled to fit the 3 dots of precision provided by the medium
* I've also used the `🮐` character to indicate maximum value observed -- I have mixed feeling about how it looks, but it does stand out.
