### PR TITLE
Set UTF-8 encoding for XML reports

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -44,6 +44,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <locale.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 
@@ -775,6 +776,9 @@ int main(
 
     /* This will check if stdout/stderr writing is successful */
     atexit(close_stdout);
+
+    /* Set encoding for reports */
+    setlocale(LC_CTYPE, "C.UTF-8");
 
     /* reset the random seed */
     init_rand();

--- a/ui/report.c
+++ b/ui/report.c
@@ -408,7 +408,7 @@ void xml_close(
     char name[MAX_FORMAT_STR];
     char buf[128];
 
-    printf("<?xml version=\"1.0\"?>\n");
+    printf("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
     printf("<MTR SRC=\"%s\" DST=\"%s\"", ctl->LocalHostname,
            ctl->Hostname);
     printf(" TOS=\"0x%X\"", ctl->tos);


### PR DESCRIPTION
I think it is a good idea to set the encoding of XML documents to UTF-8, so that a consistent result can be achieved on every platform. Furthermore, the document (can) exists without an external DTD.