### PR TITLE
net: implement addrcmp for AF_UNSPEC

### DIFF
--- a/ui/net.c
+++ b/ui/net.c
@@ -895,6 +895,7 @@ int addrcmp(
         break;
 #ifdef ENABLE_IPV6
     case AF_INET6:
+    case AF_UNSPEC:
         rc = memcmp(a, b, sizeof(struct in6_addr));
         break;
 #endif


### PR DESCRIPTION
When mtr is compiled with IPv6 enabled, the GTK frontend sets the address family to AF_UNSPEC when changing destinations. However, addrcomp does not support this AF type, which causes all comparisons to not match. For the GTK frontend, this leads to a cascading failure when setting the destination to a host that does not resolve:

1. Upon setting `ctl->af = AF_UNSPEC`, `net_max()` will report that all hops have data, as no hops can match the previous remote address.
2. The GTK frontend tries to render a row for every hop, including its IP / hostname.
3. The guard in the GTK frontend to avoid looking up unknown addresses also fails, causing mtr to flood DNS packets and effectively hang.

Fixes https://github.com/traviscross/mtr/issues/533