### PR TITLE
Initialize lines to empty string in split mode

### DIFF
--- a/ui/split.c
+++ b/ui/split.c
@@ -136,7 +136,7 @@ void split_open(
 #endif
     LineCount = -1;
     for (i = 0; i < MAX_LINE_COUNT; i++) {
-        xstrncpy(Lines[i], "???", MAX_LINE_SIZE);
+        xstrncpy(Lines[i], "", MAX_LINE_SIZE);
     }
 }
 


### PR DESCRIPTION
Split mode only prints lines that have changed, so initializing them to "???" means that unknown / hidden hops are never printed.

Fixes https://github.com/traviscross/mtr/issues/108