### PR TITLE
Raw pings output time in usec. Correct args and docs.

### DIFF
--- a/FORMATS
+++ b/FORMATS
@@ -20,7 +20,7 @@ xmitline:
 x <pos> <seqnum>
 
 pingline:
-p <pos> <pingtime (ms)> <seqnum>
+p <pos> <pingtime (usec)> <seqnum>
 
 dnsline:
 d <pos> <hostname>

--- a/ui/display.c
+++ b/ui/display.c
@@ -218,11 +218,11 @@ void display_rawxmit(
 void display_rawping(
     struct mtr_ctl *ctl,
     int host,
-    int msec,
+    int usec,
     int seq)
 {
     if (ctl->DisplayMode == DisplayRaw)
-        raw_rawping(ctl, host, msec, seq);
+        raw_rawping(ctl, host, usec, seq);
 }
 
 

--- a/ui/display.h
+++ b/ui/display.h
@@ -79,7 +79,7 @@ extern void display_rawxmit(
 extern void display_rawping(
     struct mtr_ctl *ctl,
     int hostnum,
-    int msec,
+    int usec,
     int seq);
 extern void display_rawhost(
     struct mtr_ctl *ctl,

--- a/ui/raw.c
+++ b/ui/raw.c
@@ -47,7 +47,7 @@ void raw_rawxmit(
 void raw_rawping(
     struct mtr_ctl *ctl,
     int host,
-    int msec,
+    int usec,
     int seq)
 {
     static int havename[MaxHost];
@@ -60,7 +60,7 @@ void raw_rawping(
             printf("d %d %s\n", host, name);
         }
     }
-    printf("p %d %d %d\n", host, msec, seq);
+    printf("p %d %d %d\n", host, usec, seq);
     fflush(stdout);
 }
 

--- a/ui/raw.h
+++ b/ui/raw.h
@@ -25,7 +25,7 @@ extern void raw_rawxmit(
 extern void raw_rawping(
     struct mtr_ctl *ctl,
     int host,
-    int msec,
+    int usec,
     int seq);
 extern void raw_rawhost(
     struct mtr_ctl *ctl,


### PR DESCRIPTION
An alternate solution is to correct https://github.com/traviscross/mtr/blob/master/ui/net.c#L319, but that would potentially break workflows for users, so this is likely a more acceptable fix