### PR TITLE
Legacy system build fix

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -250,7 +250,6 @@ int construct_udp6_packet(
     int packet_size,
     const struct probe_param_t *param)
 {
-    int udp_socket = net_state->platform.udp6_send_socket;
     struct UDPHeader *udp;
     int udp_size;
 

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -30,9 +30,6 @@
 #endif
 #include <errno.h>
 
-#ifdef __APPLE__
-#define BIND_8_COMPAT
-#endif
 #include <arpa/nameser.h>
 #ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>


### PR DESCRIPTION
Only try to set IPv6 ToS if the system's IPv6 stack supports RFC 3542 (IPV6_TCLASS)
Skip trying to set BIND_8_COMPAT on Darwin, since on ancient versions it breaks the build due to conflicts and an on more recent versions it either includes arpa/nameser_compat.h or on current versions, it's a no-op. - Resolves #12
While here, drop an unused variable.

Tested on OS X 10.4 to 10.6, and 10.10.