### PR TITLE
Add -D (--due-ttl) option.

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -421,6 +421,12 @@ Specifies with what TTL to start.  Defaults to 1.
 Specifies the maximum number of hops (max time-to-live value) traceroute will
 probe.  Default is 30.
 .TP
+.B \-D \fINUM\fR, \fB\-\-due-ttl \fINUM
+Specifies the minimum TTL value to achieve when sending network probes.
+Default is disabled. However, if responses from the target host were received
+on hops less than the specified value, the host address will be displayed only
+in the ECMP section of the paths.
+.TP
 .B \-U \fINUM\fR, \fB\-\-max-unknown \fINUM
 Specifies the maximum unknown host. Default is 5.
 .TP

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -102,6 +102,7 @@ struct mtr_ctl {
     int mtrtype;                /* type of query packet used */
     int fstTTL;                 /* initial hub(ttl) to ping byMin */
     int maxTTL;                 /* last hub to ping byMin */
+    int dueTTL;                 /* don't stop until reach dueTTL */
     int maxUnknown;             /* stop ping threshold */
     int maxDisplayPath;         /* maximum number of ECMP paths to display */
     int remoteport;             /* target port for TCP tracing */


### PR DESCRIPTION
Specifies the minimum TTL value that must be reached when sending network probes. The default value is disabled.
If responses from the target host were received on hops with TTL less than the specified value,
the host address will be displayed in the ECMP paths section.

This option will help with diagnostics in TCP or UDP mode in cases where network probes go along paths of different lengths.
MTR will send probes starting with TTL=1 (or firstTTL if specified) up to the value specified by the --due-ttl option.
After that, maxUnknown or maxTTL restrictions will be taken into account.

Closes feature request #295
https://github.com/traviscross/mtr/issues/295
