### PR TITLE
Exit with error when attempting to run as non-root

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -816,6 +816,11 @@ int main(
 
     parse_arg(&ctl, &names_head, argc, argv);
 
+
+    if (geteuid() != 0) {
+        error(EXIT_FAILURE, 0, "need to be run as root. Use sudo or su.");
+    }
+
     while (optind < argc) {
         char *name = argv[optind++];
         append_to_names(&names_head, name);


### PR DESCRIPTION
Give a friendlier failure message. Before:

```console
$ mtr
mtr-packet: Failure to open IPv4 sockets
mtr-packet: Failure to open IPv6 sockets
mtr: Failure to start mtr-packet: Invalid argument
```

After:

```console
$ mtr
mtr: needs to be run as root, use sudo or su.
```

`--verison` and `--help` still work as non-root.