### PR TITLE
Fix typos in comments and docstrings across codebase

### DIFF
--- a/packet/cmdparse.c
+++ b/packet/cmdparse.c
@@ -64,7 +64,7 @@ int tokenize_command(
 /*
     Parse a command string (or command reply string) into a command_t
     structure for later semantic interpretation.  Returns EINVAL if the
-    command string is unparseable or zero for success.
+    command string is unparsable or zero for success.
 
     command_string will be modified in-place with NUL characters terminating
     tokens, and the command_t will use pointers to the contents of

--- a/packet/command.c
+++ b/packet/command.c
@@ -156,7 +156,7 @@ void check_support_command(
 }
 
 /*
-    If a named send_probe argument is recognized, fill in the probe paramters
+    If a named send_probe argument is recognized, fill in the probe parameters
     structure with the argument value.
 */
 static

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -470,7 +470,7 @@ int set_stream_socket_options(
 
 
 /*
-    Open a TCP or SCTP socket, respecting the probe paramters as much as
+    Open a TCP or SCTP socket, respecting the probe parameters as much as
     we can, and use it as an outgoing probe.
 */
 static

--- a/test/linux/netem.py
+++ b/test/linux/netem.py
@@ -6,7 +6,7 @@ Description
 This small, self-contained Python library serves as a high-level API for the
 creation and management of virtual network topologies in a Linux environment.
 By leveraging Linux's networking capabilities, it allows for the dynamic
-establishment of virutal network environments, links, and complex route and rule
+establishment of virtual network environments, links, and complex route and rule
 configurations. It only relies on iproute2, libc, and Python 3.10. The core
 architecture revolves around the `Network` base class, from which custom network
 topologies can be designed. A typical use-case involves inheriting from this base
@@ -697,4 +697,3 @@ def _supported() -> Tuple[bool, Optional[str]]:
         return False, 'The ip utility must be installed (iproute2)'
 
     return True, None
-

--- a/test/mtrpacket.py
+++ b/test/mtrpacket.py
@@ -275,7 +275,7 @@ class MtrPacketTest(unittest.TestCase):
         '''Read the next reply from mtr-packet.
 
         Attempt to read the next command reply from mtr-packet.  If no reply
-        is available withing the timeout time, raise ReadReplyTimeout
+        is available within the timeout time, raise ReadReplyTimeout
         instead.'''
 
         start_time = time.time()

--- a/test/probe.py
+++ b/test/probe.py
@@ -133,7 +133,7 @@ class TestProbeICMPv4(mtrpacket.MtrPacketTest):
         self.assertIn('round-trip-time', reply.argument)
 
     def test_timeout(self):
-        'Test timeouts when sending to a non-existant address'
+        'Test timeouts when sending to a non-existent address'
 
         #
         #  Probe a non-existent address, and expect no reply


### PR DESCRIPTION
Corrected a few spelling errors such as 'unparseable' to 'unparsable', 'paramters' to 'parameters', 'virutal' to 'virtual', 'withing' to 'within', and 'non-existant' to 'non-existent' in both source and test files.