### PR TITLE
ui: fix braille display mode on Cygwin

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -73,7 +73,7 @@ static int scale[NUM_FACTORS];
 static char block_map[NUM_FACTORS];
 #ifdef WITH_BRAILLE_DISPLAY
 static const wchar_t *braille_map[NUM_FACTORS] = {
-    L"⣀", L"⣀", L"⣤", L"⣤", L"⣶", L"⣶", L"⣿", L"🮐"
+    L"⣀", L"⣀", L"⣤", L"⣤", L"⣶", L"⣶", L"⣿", L"⣿"
 };
 #endif
 
@@ -651,7 +651,7 @@ static const wchar_t *braille_char_lookup(
 
     int i = scale_ms_to_braille_factor(ms);
     if ((unsigned)i >= 4)
-        return L"🮐"; // this is the max
+        return L"⣿"; // max (U+28FF stays in BMP, safe on 16-bit wchar_t)
 
     return braille_set[i];
 }
@@ -693,7 +693,7 @@ static const wchar_t *braille_char_double(
 
     int left_i = scale_ms_to_braille_factor(left_ms);
     if ((unsigned)left_i >= 4)
-        return L"🮐"; // this is the max
+        return L"⣿"; // max (U+28FF stays in BMP, safe on 16-bit wchar_t)
 
     return braille_char_lookup(right_ms, braille_double_lookup[left_i]);
 }

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -21,6 +21,9 @@
 #include "mtr.h"
 
 #include <locale.h>
+#ifdef __CYGWIN__
+#include <windows.h>
+#endif
 #include <assert.h>
 #include <strings.h>
 #include <unistd.h>
@@ -39,7 +42,11 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#if defined(HAVE_NCURSES_H)
+/* On Cygwin, <ncurses.h> is the non-wide variant and lacks addwstr/add_wch.
+   Include <ncursesw/ncurses.h> directly when the braille display is built. */
+#if defined(__CYGWIN__) && defined(WITH_BRAILLE_DISPLAY)
+#include <ncursesw/ncurses.h>
+#elif defined(HAVE_NCURSES_H)
 #include <ncurses.h>
 #elif defined(HAVE_NCURSES_CURSES_H)
 #include <ncurses/curses.h>
@@ -717,7 +724,7 @@ static void mtr_print_braille(
         wstr = L"▁";
 
     attrset(block_col[f + 1]);
-    printw("%ls", wstr);
+    addwstr(wstr);
     attrset(A_NORMAL);
 }
 
@@ -966,7 +973,7 @@ void mtr_curses_redraw(
             attrset(block_col[i + 1]);
 #ifdef WITH_BRAILLE_DISPLAY
             if (use_braille_map)
-                printw("%ls", braille_map[i]);
+                addwstr(braille_map[i]);
             else
 #endif
                 printw("%c", block_map[i]);
@@ -988,7 +995,12 @@ void mtr_curses_open(
 
 #ifdef WITH_BRAILLE_DISPLAY
     // initialize all locale variables, before ncurses starts
-    setlocale(LC_ALL, "");
+#ifdef __CYGWIN__
+    SetConsoleOutputCP(65001);
+    SetConsoleCP(65001);
+#endif
+    if (!setlocale(LC_ALL, "C.UTF-8"))
+        setlocale(LC_ALL, "");
 #endif
 
     initscr();


### PR DESCRIPTION
## Problem

The braille display mode (`d` key to cycle) was completely broken when
mtr is built with Cygwin. The graph area showed garbled output with
misaligned characters and spurious terminal sequences.

Three separate bugs combined to cause this:

**1. Wrong ncurses header on Cygwin**

Cygwin ships `<ncurses.h>` as the non-wide variant, which does not
declare `addwstr()`, `add_wch()`, or any other wide-character ncurses
API. The build system detects `HAVE_NCURSES_H` and uses that header,
but links against `libncursesw`, so the wide functions are present in
the binary with implicit (wrong) declarations.

Fix: when `__CYGWIN__` and `WITH_BRAILLE_DISPLAY` are both defined,
include `<ncursesw/ncurses.h>` directly.

**2. `printw("%ls", ...)` instead of `addwstr()`**

Wide string output was done via `printw("%ls", wstr)`, which routes
through the C library `wcsrtombs()`. This is fragile when the locale
is not fully configured before ncurses initialises. The correct
ncursesw API is `addwstr()`.

**3. Non-BMP character U+1FB10 with 16-bit wchar_t**

On Windows/Cygwin `sizeof(wchar_t) == 2` (UTF-16). U+1FB10 lies
outside the Basic Multilingual Plane and becomes a surrogate pair in
the wchar_t string literals. ncurses calls `wcwidth()` on the high
surrogate, which returns -1 (invalid), corrupting the output.
Replaced with U+28FF (filled braille pattern), within the BMP and
visually equivalent as a "maximum" indicator.

**4. Locale and Windows console codepage**

`setlocale(LC_ALL, "")` on Cygwin inherits the Windows ANSI codepage
(e.g. CP1252) rather than UTF-8. Added an explicit `C.UTF-8` request
with fallback, and `SetConsoleOutputCP(65001)` to put the Windows
console in UTF-8 mode before ncurses initialises.

## Testing

Built and tested on Windows 11 with Cygwin 3.6.9 (gcc 13.4, ncursesw
6.x). All four display modes (`d` key) now render correctly including
braille.

## Commits

- `ui: replace non-BMP braille char U+1FB10 with U+28FF` — portable
  fix for any platform where `sizeof(wchar_t) == 2`
- `ui: fix braille display mode on Cygwin` — Cygwin-specific header,
  output function, and locale/codepage fixes
