### PR TITLE
ci: fix GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install flake8
-        run: pip3 install flake8==3.9.2 flake8-bandit==2.1.2 bandit==1.7.2
+        run: pip3 install flake8==3.9.2 flake8-bandit==2.1.2 bandit==1.7.2 pbr==7.0.3
       - name: Run flake8
         run: python3 -m flake8 .
   compile-linux:
@@ -32,4 +32,4 @@ jobs:
       - name: Run sample mtr against 1.1.1.1
         run: ./mtr --report --report-cycles 1 -m 1 1.1.1.1
       - name: Run test - cmdparse.py
-        run: python3 ./test/cmdparse.py
+        run: sudo python3 ./test/cmdparse.py


### PR DESCRIPTION
## Summary

Fix the current GitHub Actions failures on `master`:

- install `pbr==7.0.3` with the pinned flake8/bandit toolchain so `flake8-bandit` can import `bandit`, which imports `pbr.version`
- run `test/cmdparse.py` through `sudo` because it launches `mtr-packet`, and `mtr-packet` needs raw socket permissions for the exercised command parser paths

## Validation

- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j $(nproc)`
- `./mtr --report --report-cycles 1 -m 1 1.1.1.1`
- `sudo python3 ./test/cmdparse.py` (`6 tests OK`)

The latest upstream failure I checked was `Test compilation` run `25505515657`, where lint failed with `ModuleNotFoundError: No module named 'pbr'` and `cmdparse.py` timed out after `mtr-packet` failed to open IPv4/IPv6 sockets with `Permission denied`.
