### PR TITLE
packet: document and constrain default UDP ports

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -446,9 +446,16 @@ Use Stream Control Transmission Protocol packets instead of ICMP ECHO.
 .TP
 .B \-P \fIPORT\fR, \fB\-\-port \fIPORT
 The target port number for TCP/SCTP/UDP traces.
+When this option is not given, TCP and SCTP traces use port 80.
+UDP traces encode the probe sequence number in the destination port
+instead, so the destination port changes for each probe.
 .TP
 .B \-L \fILOCALPORT\fR, \fB\-\-localport \fILOCALPORT
-The source port number for UDP traces.
+The source port number for UDP traces.  When this option is not given,
+UDP traces use the mtr process ID as the source port, unless
+.B \-\-port
+was given; in that case, UDP traces encode the probe sequence number in
+the source port instead.
 .TP
 .B \-Z \fISECONDS\fR, \fB\-\-timeout \fISECONDS
 The number of seconds to keep probe sockets open before giving up on

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -452,7 +452,8 @@ instead, so the destination port changes for each probe.
 .TP
 .B \-L \fILOCALPORT\fR, \fB\-\-localport \fILOCALPORT
 The source port number for UDP traces.  When this option is not given,
-UDP traces use the mtr process ID as the source port, unless
+UDP traces use the low 16 bits of the mtr process ID as the source port,
+rotating privileged ports into the high end of the UDP port range unless
 .B \-\-port
 was given; in that case, UDP traces encode the probe sequence number in
 the source port instead.

--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -38,11 +38,26 @@
 #include <sys/capability.h>
 #endif
 
+#define MIN_UNPRIVILEGED_PORT 1024
+#define UDP_PORT_RANGE 65536
+
 /*  A source of data for computing a checksum  */
 struct checksum_source_t {
     const void *data;
     size_t size;
 };
+
+static
+uint16_t udp_source_port_from_pid(void)
+{
+    uint16_t port = getpid() & 0xffff;
+
+    if (port < MIN_UNPRIVILEGED_PORT) {
+        port += UDP_PORT_RANGE - MIN_UNPRIVILEGED_PORT;
+    }
+
+    return port;
+}
 
 /*  Compute the IP checksum (or ICMP checksum) of a packet.  */
 static
@@ -164,7 +179,7 @@ void set_udp_ports(
         if (param->local_port) {
             udp->srcport = htons(param->local_port);
         } else {
-            udp->srcport = htons(getpid());
+            udp->srcport = htons(udp_source_port_from_pid());
         }
 
         udp->checksum = 0;


### PR DESCRIPTION
## Summary

Document the default port behavior requested in #517 and address the follow-up from @rewolff:

- TCP and SCTP traces use target port 80 when `--port` is not given
- UDP traces use the probe sequence number as the destination port when `--port` is not given
- UDP source port defaults to the low 16 bits of the mtr process ID, adjusted out of the privileged port range if needed
- when `--port` is set for UDP, the sequence number moves to the source port as before

This matches `ui/mtr.c` and `packet/construct_unix.c`, and avoids defaulting UDP probes to a privileged source port when modern large PIDs truncate below 1024.

Fixes #517.

## Validation

- `make mtr.8`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j $(nproc)`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `./mtr --report --report-cycles 1 -m 1 1.1.1.1`
- `sudo python3 ./test/cmdparse.py` (`6 tests OK`)
- `git diff --check`

## CI note

This is intentionally left as a draft until #570 lands. The current failing checks on this branch are the existing `master` workflow failures fixed by #570, not failures introduced by this branch.
