### PR TITLE
net: reject unspecified destination addresses

### DIFF
--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -248,8 +248,8 @@ static gint Host_activate(
 
     ctl->af = DEFAULT_AF;  // should this obey the cmd line option?
     ctl->Hostname = gtk_entry_get_text(GTK_ENTRY(entry));
-    if (get_addrinfo_from_name(ctl, &res, ctl->Hostname) == 0) {
-        net_reopen(ctl, res);
+    if (get_addrinfo_from_name(ctl, &res, ctl->Hostname) == 0 &&
+        net_reopen(ctl, res) == 0) {
         freeaddrinfo(res);
         net_send_batch(ctl);
         /* If we are "Paused" at this point it is usually because someone
@@ -257,6 +257,9 @@ static gint Host_activate(
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(Pause_Button), 0);
     } else {
         int pos = strlen(gtk_entry_get_text(GTK_ENTRY(entry)));
+        if (res) {
+            freeaddrinfo(res);
+        }
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(Pause_Button), 1);
         gtk_editable_insert_text(GTK_EDITABLE(entry), ": not found", -1,
                                  &pos);

--- a/ui/net.c
+++ b/ui/net.c
@@ -768,23 +768,27 @@ int net_open(
 {
     int err;
 
+    if (!addrcmp(sockaddr_addr_offset(res->ai_addr), &ctl->unspec_addr, res->ai_family))
+        return -1;
+
     /*  Spawn the mtr-packet child process  */
     err = open_command_pipe(ctl, &packet_command_pipe);
     if (err) {
         return err;
     }
 
-    net_reopen(ctl, res);
-
-    return 0;
+    return net_reopen(ctl, res);
 }
 
 
-void net_reopen(
+int net_reopen(
     struct mtr_ctl *ctl,
     struct addrinfo *res)
 {
     int at;
+
+    if (!addrcmp(sockaddr_addr_offset(res->ai_addr), &ctl->unspec_addr, res->ai_family))
+        return -1;
 
     for (at = 0; at < MaxHost; at++) {
         memset(&host[at], 0, sizeof(host[at]));
@@ -809,6 +813,7 @@ void net_reopen(
         net_find_local_address(ctl);
     }
 
+    return 0;
 }
 
 

--- a/ui/net.h
+++ b/ui/net.h
@@ -34,7 +34,7 @@
 extern int net_open(
     struct mtr_ctl *ctl,
     struct addrinfo *res);
-extern void net_reopen(
+extern int net_reopen(
     struct mtr_ctl *ctl,
     struct addrinfo *res);
 extern void net_reset(


### PR DESCRIPTION
## Summary

Reject unspecified destination addresses such as `0` before starting `mtr-packet`, and reject the same addresses when the GTK frontend changes destination through the hostname field.

This keeps mtr from treating `0.0.0.0` as a usable trace target and then rendering localhost-looking output. The initial failure path still happens before opening the packet command pipe, and the GTK reopen path now fails before resetting the existing trace state.

Fixes #471.

## Validation

- `./configure --without-jansson`
- `make -j$(nproc)`
- `git diff --check`
- `./mtr -r -c 1 0` exits non-zero
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`

The GTK-enabled build still prints the existing `ui/split.c` `snprintf` truncation warnings and a GTK icon-loader deprecation warning on this compiler; those warnings are present on the current code path and are not introduced by this PR.
