### PR TITLE
mtr: avoid undefined behavior in random seed

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -712,7 +712,7 @@ static void init_rand(
     struct timeval tv;
 
     gettimeofday(&tv, NULL);
-    srand((getpid() << 16) ^ getuid() ^ tv.tv_sec ^ tv.tv_usec);
+    srand(((getpid() & 0xffff) << 16) ^ getuid() ^ tv.tv_sec ^ tv.tv_usec);
 }
 
 /*


### PR DESCRIPTION
## Summary

Mask the process id before shifting it into the random seed.

Large process ids can make `getpid() << 16` overflow signed `int`, which UBSan reports during startup. This is the same minimal fix from the long-standing clean PR #384, opened on a fresh branch so it can be merged against current `master`.

Fixes #383.
Supersedes #384.

## Attribution

Original patch by Aaron Lipinski in #384.

## Validation

- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j $(nproc)`
- `git diff --check`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`

The build still prints the existing `ui/split.c` `snprintf` truncation warnings on this compiler; those warnings are present on the current code path and are not introduced by this PR.
