### PR TITLE
csv: omit trailing empty header field

### DIFF
--- a/ui/report.c
+++ b/ui/report.c
@@ -570,10 +570,10 @@ void csv_close(
         snprint_hop_name(ctl, name, sizeof(name), at, addr);
 
         if (at == net_min(ctl)) {
-            printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip,");
+            printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip");
 #ifdef HAVE_IPINFO
             if (ipinfo_field_selected(ctl, 0)) {
-                printf("Asn,");
+                printf(",Asn");
             }
 #endif
             for (i = 0; i < MAXFLD; i++) {
@@ -584,7 +584,7 @@ void csv_close(
                     printf(",");
                     continue;
                 }
-                printf("%s,", data_fields[j].title);
+                printf(",%s", data_fields[j].title);
             }
             printf("\n");
         }
@@ -608,7 +608,6 @@ void csv_close(
                 printf(",");
                 continue;
             }
-
             /* 1000.0 is a temporary hack for stats usec to ms, impacted net_loss. */
             if (strchr(data_fields[j].format, 'f')) {
                 printf(",%.2f",
@@ -665,7 +664,6 @@ void csv_close(
                             printf(",");
                             continue;
                         }
-
                         /* 1000.0 is a temporary hack for stats usec to ms, impacted net_loss. */
                         if (strchr(data_fields[j].format, 'f')) {
                             printf(",%.2f",


### PR DESCRIPTION
## Summary

Stop emitting a trailing delimiter at the end of the CSV header line.

The existing spacer field behavior is preserved: if the active field list contains a space field, CSV output keeps that column so existing column positions do not move. This only removes the unintended final empty header field.

Fixes #451.

## Validation

- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j32`
- `sudo -n ./mtr --report-cycles 1 --report --csv 127.0.0.1`
- Python `csv` check verifying:
  - header/data row counts match
  - the spacer column is still present as an empty CSV field
  - the last header/data field is not empty
- `git diff --check`
