### PR TITLE
options: parse quoted MTR_OPTIONS arguments

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -686,22 +686,63 @@ static void parse_mtr_options(
     char *string)
 {
     int argc = 1;
-    char *argv[128], *p;
+    char *argv[128], *arg, *input, *output, *option_string;
+    int quote;
 
     if (!string)
         return;
     argv[0] = xstrdup(PACKAGE_NAME);
-    argc = 1;
-    p = strtok(string, " \t");
-    while (p != NULL && ((size_t) argc < (sizeof(argv) / sizeof(argv[0])))) {
-        argv[argc++] = p;
-        p = strtok(NULL, " \t");
+    option_string = xstrdup(string);
+    input = option_string;
+    output = option_string;
+
+    while ((size_t) argc < (sizeof(argv) / sizeof(argv[0]))) {
+        while (*input && isspace((unsigned char) *input))
+            input++;
+        if (!*input)
+            break;
+
+        arg = output;
+        quote = 0;
+        while (*input) {
+            if (quote) {
+                if (*input == quote) {
+                    input++;
+                    quote = 0;
+                } else if (*input == '\\' && input[1]) {
+                    input++;
+                    *output++ = *input++;
+                } else {
+                    *output++ = *input++;
+                }
+            } else if (isspace((unsigned char) *input)) {
+                break;
+            } else if (*input == '"' || *input == '\'') {
+                quote = *input++;
+            } else if (*input == '\\' && input[1]) {
+                input++;
+                *output++ = *input++;
+            } else {
+                *output++ = *input++;
+            }
+        }
+
+        if (quote) {
+            error(EXIT_FAILURE, 0, "unterminated quote in MTR_OPTIONS");
+        }
+        if (*input && isspace((unsigned char) *input)) {
+            input++;
+        }
+
+        *output++ = '\0';
+        argv[argc++] = arg;
     }
-    if (p != NULL) {
-        error(0, 0, "Warning: extra arguments ignored: %s", p);
+    if (*input) {
+        error(0, 0, "Warning: extra arguments ignored: %s", input);
     }
 
     parse_arg(ctl, names, argc, argv);
+    free(option_string);
     free(argv[0]);
     optind = 0;
 }


### PR DESCRIPTION
## Summary

Parse `MTR_OPTIONS` with shell-style quotes and backslash escapes instead of splitting only on whitespace.

This allows field orders containing spaces to be configured through the environment, for example:

```sh
MTR_OPTIONS='-o "LSD W" -r -c 1' mtr 127.0.0.1
MTR_OPTIONS='-r -c 1 -o "LSD W"' mtr 127.0.0.1
```

Unterminated quotes now fail with a clear `MTR_OPTIONS` error instead of risking broken parsing.

Fixes #236.
Fixes #287.

## Validation

- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j $(nproc)`
- `MTR_OPTIONS='-o "LSD W" -r -c 1' ./mtr 127.0.0.1`
- `MTR_OPTIONS='-r -c 1 -o "LSD W"' ./mtr 127.0.0.1`
- `git diff --check`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`

The build still prints the existing `ui/split.c` `snprintf` truncation warnings on this compiler; those warnings are present on the current code path and are not introduced by this PR.
