### PR TITLE
fix(install): honor transformed packet helper

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,8 +41,13 @@ dist_man_MANS = mtr.8 mtr-packet.8
 PATHFILES += man/mtr.8 man/mtr-packet.8
 
 install-exec-hook:
-	`setcap cap_net_raw+ep $(DESTDIR)$(sbindir)/mtr-packet` \
-	|| chmod u+s $(DESTDIR)$(sbindir)/mtr-packet
+	mtr_packet_name=`echo mtr-packet | sed '$(transform)'`; \
+	if command -v setcap >/dev/null 2>&1; then \
+		setcap cap_net_raw+ep $(DESTDIR)$(sbindir)/$$mtr_packet_name \
+		|| chmod u+s $(DESTDIR)$(sbindir)/$$mtr_packet_name; \
+	else \
+		chmod u+s $(DESTDIR)$(sbindir)/$$mtr_packet_name; \
+	fi
 
 mtr_SOURCES = ui/mtr.c ui/mtr.h \
               ui/net.c ui/net.h \

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,22 @@ AC_ARG_ENABLE([bash-completion],
   [], [enable_bash_completion=yes]
 )
 AM_CONDITIONAL([BUILD_BASH_COMPLETION], [test "x$enable_bash_completion" = xyes])
+
+mtr_packet_prefix=
+mtr_packet_suffix=
+AS_IF([test "x$program_prefix" != "xNONE"], [
+  mtr_packet_prefix=$program_prefix
+])
+AS_IF([test "x$program_suffix" != "xNONE"], [
+  mtr_packet_suffix=$program_suffix
+])
+MTR_PACKET_NAME="${mtr_packet_prefix}mtr-packet${mtr_packet_suffix}"
+AC_SUBST([MTR_PACKET_NAME])
+AC_DEFINE_UNQUOTED(
+  [MTR_PACKET_NAME],
+  ["$MTR_PACKET_NAME"],
+  [Name of the installed mtr-packet executable after program transforms.])
+
 echo "build options:"
 echo "--------------"
 echo "libasan  :$with_libasan"

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -215,6 +215,7 @@ void execute_packet_child(
     void)
 {
     char buf[256];
+    char *path_end;
     /*
        Allow the MTR_PACKET environment variable to override
        the path to the mtr-packet executable.  This is necessary
@@ -230,25 +231,34 @@ void execute_packet_child(
     if (access ("/etc/mtr.is.run.under.sudo", F_OK) != 0)
         mtr_packet_path = getenv("MTR_PACKET");
     if (mtr_packet_path == NULL)
-        mtr_packet_path = "mtr-packet";
+        mtr_packet_path = MTR_PACKET_NAME;
 
     /*
        First, try to execute mtr-packet from PATH
        or MTR_PACKET environment variable.
      */
-    execlp(mtr_packet_path, "mtr-packet", (char *) NULL);
+    execlp(mtr_packet_path, MTR_PACKET_NAME, (char *) NULL);
 
     /*
        Then try to find it where WE were executed from.
      */
-    strncpy (buf, myname, 240);
-    strcat (buf, "-packet");
-    mtr_packet_path = buf;
-    execl(mtr_packet_path, "mtr-packet", (char *) NULL);
+    path_end = strrchr(myname, '/');
+
+    if (path_end != NULL) {
+        size_t dir_length = path_end - myname + 1;
+
+        if (dir_length + strlen(MTR_PACKET_NAME) < sizeof(buf)) {
+            memcpy(buf, myname, dir_length);
+            strcpy(buf + dir_length, MTR_PACKET_NAME);
+            mtr_packet_path = buf;
+            execl(mtr_packet_path, MTR_PACKET_NAME, (char *) NULL);
+        }
+    }
 
     /*
        If mtr-packet is not found, try to use mtr-packet from current directory
      */
+    execl("./" MTR_PACKET_NAME, "./" MTR_PACKET_NAME, (char *) NULL);
     execl("./mtr-packet", "./mtr-packet", (char *) NULL);
 
     /*  Both exec attempts failed, so nothing to do but exit  */


### PR DESCRIPTION
Fixes #191.
Fixes #203.
Supersedes #583.

## Summary
- install capabilities/setuid fallback on the transformed `mtr-packet` program name
- avoid noisy `setcap: command not found` output by checking whether `setcap` is available before using it
- teach runtime lookup to prefer the transformed packet helper name while keeping `MTR_PACKET` and `./mtr-packet` debugging fallback support

## Validation
- `./bootstrap.sh`
- `./configure --program-prefix=x --prefix=/tmp/mtr-transform-combined`
- `make -j$(nproc)`
- `git diff --check`
- `PATH=/usr/bin:/bin make install DESTDIR=/tmp/mtr-transform-install` installs `xmtr-packet` without setcap lookup noise and applies setuid fallback
- `/tmp/mtr-transform-install/tmp/mtr-transform-combined/sbin/xmtr -r -c 1 127.0.0.1`