### PR TITLE
build: search terminal info libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,10 @@ AS_IF([test "x$with_ncurses" = "xyes"],
     [initscr], [ncursesw ncurses curses],
     [AC_DEFINE([HAVE_CURSES], [1], [Define if a curses library available])],
     [with_ncurses=no])
+   AC_SEARCH_LIBS(
+     [raw], [tinfow tinfo termcap],
+     [],
+     [with_ncurses=no])
 ])
 AM_CONDITIONAL([WITH_CURSES], [test "x$with_ncurses" = xyes])
 


### PR DESCRIPTION
## Summary

Search terminal-info libraries when curses support is enabled.

Some distributions split terminal state functions out of ncurses/ncursesw, so linking curses code can require an additional `tinfow`, `tinfo`, or `termcap` library. This is a refreshed version of the old #368 idea, with `tinfow` checked first so the current ncursesw path keeps the matching wide-character terminal-info library when needed.

Supersedes #368.

Authorship note: the branch keeps Jeroen Roovers as the commit author for the refreshed #368 libtinfo lookup, with the current-tree adaptation co-authored by Darafei.

## Validation

- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- verified configure checks for `wprintw`, `initscr`, and `raw`
- `make -j $(nproc)`
- `git diff --check`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`

The build still prints the existing `ui/split.c` `snprintf` truncation warnings on this compiler; those warnings are present on the current code path and are not introduced by this PR.

