### PR TITLE
packet: rename shared UDP checksum helper

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -175,8 +175,8 @@ void set_udp_ports(
 
 /* Prepend pseudoheader to the udp datagram and calculate checksum */
 static
-int udp4_checksum(void *pheader, void *udata, int psize, int dsize,
-                  int alt_checksum)
+int udp_checksum(void *pheader, void *udata, int psize, int dsize,
+                 int alt_checksum)
 {
     unsigned int totalsize = psize + dsize;
     unsigned char csumpacket[totalsize];
@@ -234,7 +234,7 @@ int construct_udp4_packet(
                                                   udp_size +
                                                   sizeof(struct UDPHeader)];
     }
-    *checksum_off = htons(udp4_checksum(&udph, udp,
+    *checksum_off = htons(udp_checksum(&udph, udp,
                                         sizeof(struct UDPPseudoHeader),
                                         udp_size, udp->checksum != 0));
 
@@ -277,7 +277,7 @@ int construct_udp6_packet(
          checksum_off is udp payload */
         checksum_off = (uint16_t *)&packet_buffer[sizeof(struct UDPHeader)];
     }
-    *checksum_off = htons(udp4_checksum(&udph, udp,
+    *checksum_off = htons(udp_checksum(&udph, udp,
                                         sizeof(struct IP6PseudoHeader),
                                         udp_size, udp->checksum != 0));
     return 0;


### PR DESCRIPTION
## Summary

- rename the shared UDP checksum helper from `udp4_checksum` to `udp_checksum`
- keep the IPv4 and IPv6 call sites aligned with the shared helper name

This is a fresh replacement for #490. Current `master` no longer has the obsolete unused IPv6 UDP socket parameter from that PR, so this keeps only the still-relevant helper rename.

Supersedes #490.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
