### PR TITLE
test: cover TTL option validation

### DIFF
--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -17,13 +17,60 @@
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-'''Test mtr-packet's command parsing.'''
+'''Test mtr and mtr-packet command parsing.'''
 
 
+import os
+import subprocess
 import time
 import unittest
 
 import mtrpacket
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MTR = os.path.join(PROJECT_ROOT, 'mtr')
+
+
+class TestMtrCommandParse(unittest.TestCase):
+    '''Test cases with malformed mtr command-line arguments.'''
+
+    def run_mtr(self, *args):
+        return subprocess.run(
+            [MTR] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+    def test_first_ttl_cannot_exceed_max_ttl(self):
+        'Test that conflicting first/max TTL options fail fast.'
+
+        reply = self.run_mtr('--first-ttl', '91', '--max-ttl', '90')
+
+        self.assertNotEqual(reply.returncode, 0)
+        self.assertIn(
+            'firstTTL(91) cannot be larger than maxTTL(90)',
+            reply.stderr,
+        )
+
+    def test_first_ttl_can_equal_max_ttl(self):
+        'Test that a single requested TTL depth remains valid.'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '--first-ttl',
+            '91',
+            '--max-ttl',
+            '91',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
 
 
 class TestCommandParse(mtrpacket.MtrPacketTest):


### PR DESCRIPTION
## Summary

- add regression coverage for `--first-ttl` greater than `--max-ttl`
- verify that equal first/max TTL values remain accepted for a single requested probe depth
- keep the coverage in `test/cmdparse.py`, which is already run by the current GitHub Actions workflow

Fixes #521.

## Validation

- `git diff --check HEAD~1..HEAD`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
