### PR TITLE
build: honor transformed mtr-packet name

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,8 +41,9 @@ dist_man_MANS = mtr.8 mtr-packet.8
 PATHFILES += man/mtr.8 man/mtr-packet.8
 
 install-exec-hook:
-	`setcap cap_net_raw+ep $(DESTDIR)$(sbindir)/mtr-packet` \
-	|| chmod u+s $(DESTDIR)$(sbindir)/mtr-packet
+	mtr_packet_name=`echo mtr-packet | sed '$(transform)'`; \
+	`setcap cap_net_raw+ep $(DESTDIR)$(sbindir)/$$mtr_packet_name` \
+	|| chmod u+s $(DESTDIR)$(sbindir)/$$mtr_packet_name
 
 mtr_SOURCES = ui/mtr.c ui/mtr.h \
               ui/net.c ui/net.h \

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,22 @@ AC_ARG_ENABLE([bash-completion],
   [], [enable_bash_completion=yes]
 )
 AM_CONDITIONAL([BUILD_BASH_COMPLETION], [test "x$enable_bash_completion" = xyes])
+
+mtr_packet_prefix=
+mtr_packet_suffix=
+AS_IF([test "x$program_prefix" != "xNONE"], [
+  mtr_packet_prefix=$program_prefix
+])
+AS_IF([test "x$program_suffix" != "xNONE"], [
+  mtr_packet_suffix=$program_suffix
+])
+MTR_PACKET_NAME="${mtr_packet_prefix}mtr-packet${mtr_packet_suffix}"
+AC_SUBST([MTR_PACKET_NAME])
+AC_DEFINE_UNQUOTED(
+  [MTR_PACKET_NAME],
+  ["$MTR_PACKET_NAME"],
+  [Name of the installed mtr-packet executable after program transforms.])
+
 echo "build options:"
 echo "--------------"
 echo "libasan  :$with_libasan"

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -215,6 +215,7 @@ void execute_packet_child(
     void)
 {
     char buf[256];
+    char *path_end;
     /*
        Allow the MTR_PACKET environment variable to override
        the path to the mtr-packet executable.  This is necessary
@@ -230,25 +231,34 @@ void execute_packet_child(
     if (access ("/etc/mtr.is.run.under.sudo", F_OK) != 0)
         mtr_packet_path = getenv("MTR_PACKET");
     if (mtr_packet_path == NULL)
-        mtr_packet_path = "mtr-packet";
+        mtr_packet_path = MTR_PACKET_NAME;
 
     /*
        First, try to execute mtr-packet from PATH
        or MTR_PACKET environment variable.
      */
-    execlp(mtr_packet_path, "mtr-packet", (char *) NULL);
+    execlp(mtr_packet_path, MTR_PACKET_NAME, (char *) NULL);
 
     /*
        Then try to find it where WE were executed from.
      */
-    strncpy (buf, myname, 240);
-    strcat (buf, "-packet");
-    mtr_packet_path = buf;
-    execl(mtr_packet_path, "mtr-packet", (char *) NULL);
+    path_end = strrchr(myname, '/');
+
+    if (path_end != NULL) {
+        size_t dir_length = path_end - myname + 1;
+
+        if (dir_length + strlen(MTR_PACKET_NAME) < sizeof(buf)) {
+            memcpy(buf, myname, dir_length);
+            strcpy(buf + dir_length, MTR_PACKET_NAME);
+            mtr_packet_path = buf;
+            execl(mtr_packet_path, MTR_PACKET_NAME, (char *) NULL);
+        }
+    }
 
     /*
        If mtr-packet is not found, try to use mtr-packet from current directory
      */
+    execl("./" MTR_PACKET_NAME, "./" MTR_PACKET_NAME, (char *) NULL);
     execl("./mtr-packet", "./mtr-packet", (char *) NULL);
 
     /*  Both exec attempts failed, so nothing to do but exit  */


### PR DESCRIPTION
## Summary

- apply the configured program transform to the installed `mtr-packet` privilege hook
- define the transformed packet helper name for runtime lookup when `--program-prefix` or `--program-suffix` is used
- keep the untransformed `./mtr-packet` build-tree fallback for local testing/debugging

Fixes #191.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson --program-suffix=-0.99-test`
- verified `config.h` defines `MTR_PACKET_NAME "mtr-packet-0.99-test"`
- verified `make -n install-exec-hook` applies the configured make transform
- `make -j "$(nproc)"` with suffix configure
- `./mtr --report --report-cycles 1 -m 1 127.0.0.1` with suffix configure
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
