### PR TITLE
curses: add report snapshot on exit

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -194,6 +194,11 @@ mode.  When in this mode,
 .B mtr
 will not cut hostnames in the report.
 .TP
+.B \-\-report\-on\-exit
+Use this option with the curses interface to print a report snapshot after
+leaving curses mode. This keeps the last trace visible in terminals that switch
+to an alternate screen while curses is active.
+.TP
 .B \-x\fR, \fB\-\-xml
 Use this option to tell
 .B mtr

--- a/ui/display.c
+++ b/ui/display.c
@@ -146,6 +146,8 @@ void display_close(
         asn_close(ctl);
 #endif
         mtr_curses_close();
+        if (ctl->ReportOnExit)
+            report_close(ctl);
         break;
 #endif
     case DisplaySplit:

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -124,6 +124,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 #endif       
     fputs(" -r, --report                     output using report mode\n", out);
     fputs(" -w, --report-wide                output wide report\n", out);
+    fputs("     --report-on-exit             print report after curses exits\n", out);
     fputs(" -c, --report-cycles COUNT        set the number of pings sent\n", out);       
 #ifdef HAVE_JANSSON       
     fputs(" -j, --json                       output json\n", out);
@@ -301,9 +302,10 @@ static void parse_arg(
      */
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
-        OPT_IPINFO4 = CHAR_MAX + 2,
+        OPT_REPORT_ON_EXIT = CHAR_MAX + 2,
+        OPT_IPINFO4 = CHAR_MAX + 3,
 #ifdef ENABLE_IPV6
-        OPT_IPINFO6 = CHAR_MAX + 3,
+        OPT_IPINFO6 = CHAR_MAX + 4,
 #endif /* ifdef ENABLE_IPV6 */
     };
     static const struct option long_options[] = {
@@ -319,6 +321,7 @@ static void parse_arg(
 
         {"report", 0, NULL, 'r'},
         {"report-wide", 0, NULL, 'w'},
+        {"report-on-exit", 0, NULL, OPT_REPORT_ON_EXIT},
         {"xml", 0, NULL, 'x'},
 #ifdef HAVE_CURSES
         {"curses", 0, NULL, 't'},
@@ -411,6 +414,9 @@ static void parse_arg(
         case 'w':
             ctl->reportwide = 1;
             ctl->DisplayMode = DisplayReport;
+            break;
+        case OPT_REPORT_ON_EXIT:
+            ctl->ReportOnExit = 1;
             break;
 #ifdef HAVE_CURSES
         case 't':

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -118,7 +118,8 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
+        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5,
+        CompactLayout:1, ReportOnExit:1;
 #ifdef HAVE_IPINFO
 #ifdef ENABLE_IPV6
     char *ipinfo_provider6;


### PR DESCRIPTION
## Summary

- add an opt-in `--report-on-exit` flag for the curses interface
- close curses normally, then print a standard report snapshot so the last trace remains visible in terminals that use an alternate screen
- document the new option in `mtr(8)` and `--help`

This follows the workaround discussed in #323 without changing the default curses behavior for existing users.

Fixes #323.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `./mtr --help 2>&1 | grep -F -- --report-on-exit`
- `script -q -e -c "sh -c 'sleep 1; printf q' | ./mtr --report-on-exit --curses --no-dns --max-ttl 1 localhost" /tmp/mtr-report-on-exit.typescript`
