### PR TITLE
curses: include hostname in title

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -876,8 +876,8 @@ void mtr_curses_redraw(
 
     move(0, 0);
     attron(A_BOLD);
-    snprintf(buf, sizeof(buf), "%s%s%s", "My traceroute  [v",
-             PACKAGE_VERSION, "]");
+    snprintf(buf, sizeof(buf), "My traceroute on %s  [v%s]",
+             ctl->LocalHostname, PACKAGE_VERSION);
     pwcenter(buf);
     attroff(A_BOLD);
 


### PR DESCRIPTION
## Summary

- include the local hostname in the centered curses title
- keep the existing source/destination line below unchanged

This implements the small title change requested in #121 so multiple running mtr instances are easier to distinguish.

Fixes #121.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `script -q -e -c "sh -c 'sleep 1; printf q' | ./mtr --curses --no-dns --max-ttl 1 localhost" /tmp/mtr-title.typescript` and verified the title contains `My traceroute on $(hostname)`
