### PR TITLE
report: preflight multiple target families

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -184,6 +184,14 @@ generates a significant amount of network traffic.  Using
 .B mtr
 to measure the quality of your network may result in decreased
 network performance.
+.PP
+Report mode can process multiple hosts in sequence. All hosts in one
+invocation must resolve to the same address family; use separate invocations
+or force an address family with
+.B \-4
+or
+.B \-6
+when tracing mixed IPv4 and IPv6 targets.
 .TP
 .B \-w\fR, \fB\-\-report\-wide
 This option puts

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -749,6 +749,61 @@ int get_addrinfo_from_name(
 }
 
 
+static int count_names(
+    names_t *names)
+{
+    int count = 0;
+
+    while (names != NULL) {
+        count++;
+        names = names->next;
+    }
+
+    return count;
+}
+
+
+static int validate_report_targets(
+    struct mtr_ctl *ctl,
+    names_t *names)
+{
+    struct mtr_ctl lookup_ctl = *ctl;
+
+    while (names != NULL) {
+        int gai_error;
+        struct addrinfo hints;
+        struct addrinfo *res = NULL;
+
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = lookup_ctl.af;
+        hints.ai_socktype = SOCK_DGRAM;
+        gai_error = getaddrinfo(names->name, NULL, &hints, &res);
+        if (gai_error) {
+            if (gai_error == EAI_SYSTEM) {
+                error(0, 0, "Failed to resolve host: %s", names->name);
+            } else {
+                error(0, 0, "Failed to resolve host: %s: %s", names->name,
+                      gai_strerror(gai_error));
+            }
+#if defined(ENABLE_IPV6) && defined(EAI_ADDRFAMILY)
+            if (gai_error == EAI_ADDRFAMILY && lookup_ctl.af != AF_UNSPEC) {
+                error(0, 0,
+                      "multiple report targets must use the same address family");
+            }
+#endif
+            return -1;
+        }
+
+        lookup_ctl.af = res->ai_family;
+        freeaddrinfo(res);
+        names = names->next;
+    }
+
+    ctl->af = lookup_ctl.af;
+    return 0;
+}
+
+
 int main(
     int argc,
     char **argv)
@@ -824,6 +879,11 @@ int main(
     /* default: localhost. */
     if (!names_head)
         append_to_names(&names_head, "localhost");
+
+    if (!ctl.Interactive && count_names(names_head) > 1 &&
+        validate_report_targets(&ctl, names_head) != 0) {
+        return EXIT_FAILURE;
+    }
 
     names_walk = names_head;
     while (names_walk != NULL) {


### PR DESCRIPTION
## Summary

- preflight multiple non-interactive targets before starting the first report
- fail immediately when later targets cannot resolve with the address family selected by earlier targets
- document that report mode can process multiple targets, but one invocation must use a single address family

This makes cases like `mtr -r 1 2001:db8::babe` fail before tracing `0.0.0.1`, with an address-family hint instead of producing a partial report followed by a surprising resolver error.

Fixes #519.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `./mtr -r 1 2001:db8::babe` exits before printing `Start:`
- `./mtr -r -c 1 --no-dns 127.0.0.1 127.0.0.1` still prints two reports
- `./mtr -r -c 1 127.0.0.1 nonexistent.invalid` keeps the normal resolver error without the address-family hint
