### PR TITLE
docs: explain stripchart markers

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -221,6 +221,11 @@ Use this option to select the initial display mode: 0 (default)
 selects statistics, 1 selects the stripchart without latency
 information, and 2 selects the stripchart with latency
 information.
+In stripchart modes,
+.B ?
+marks a probe that has not received a response, and
+.B >
+marks a response slower than the largest latency bucket shown in the scale.
 .TP
 .B \-g\fR, \fB\-\-gtk
 Use this option to force


### PR DESCRIPTION
## Summary

- document the `?` marker in stripchart display modes as a probe without a response
- document the `>` marker as a response above the largest displayed latency bucket

Fixes #405.
Fixes #13.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- verified generated `mtr.8` contains the new stripchart marker explanation
