### PR TITLE
curses: show probe protocol in title

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -139,6 +139,26 @@ static char *format_number(
 }
 
 
+static const char *probe_protocol_name(
+    int protocol)
+{
+    switch (protocol) {
+    case IPPROTO_ICMP:
+        return "ICMP";
+    case IPPROTO_UDP:
+        return "UDP";
+    case IPPROTO_TCP:
+        return "TCP";
+#ifdef HAS_SCTP
+    case IPPROTO_SCTP:
+        return "SCTP";
+#endif
+    default:
+        return "unknown";
+    }
+}
+
+
 int mtr_curses_keyaction(
     struct mtr_ctl *ctl)
 {
@@ -876,8 +896,8 @@ void mtr_curses_redraw(
 
     move(0, 0);
     attron(A_BOLD);
-    snprintf(buf, sizeof(buf), "%s%s%s", "My traceroute  [v",
-             PACKAGE_VERSION, "]");
+    snprintf(buf, sizeof(buf), "%s%s%s%s", "My traceroute  [v",
+             PACKAGE_VERSION, "] ", probe_protocol_name(ctl->mtrtype));
     pwcenter(buf);
     attroff(A_BOLD);
 


### PR DESCRIPTION
## Summary

- add the active probe protocol to the curses title line
- update the title automatically after switching with `t` or `u`, since redraw reads the current `mtrtype`

Fixes #482.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `sudo python3 ./test/cmdparse.py`
