### PR TITLE
report: print partial output on interrupt

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -45,6 +45,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <locale.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 
@@ -868,6 +869,10 @@ int main(
         display_close(&ctl);
         unlock(stdout);
 
+        if (ctl.Interrupted) {
+            exit_val = 128 + SIGINT;
+            break;
+        }
         if (ctl.Interactive)
             break;
         else

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -113,6 +113,7 @@ struct mtr_ctl {
     int fld_index[FLD_INDEX_SZ];        /* default display field (defined by key in net.h) and order */
     char available_options[MAXFLD];
     int display_offset;         /* only used in text mode */
+    int Interrupted;
     void *gtk_data;             /* pointer to hold arbitrary gtk data */
     unsigned int                /* bit field to hold named booleans */
      ForceMaxPing:1,

--- a/ui/select.c
+++ b/ui/select.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+#include <signal.h>
 #ifdef HAVE_ERROR_H
 #include <error.h>
 #else
@@ -42,6 +43,15 @@
 #include "select.h"
 
 #define MIN_DISPLAY_REDRAW_USEC 100000
+
+static volatile sig_atomic_t interrupted;
+
+static void interrupt_handler(
+    int signum ATTRIBUTE_UNUSED)
+{
+    interrupted = 1;
+}
+
 
 static int timeval_after_or_equal(
     const struct timeval *a,
@@ -113,12 +123,20 @@ void select_loop(
     struct timeval intervaltime;
     static double dnsinterval = 0;
 
+    interrupted = 0;
+    signal(SIGINT, interrupt_handler);
+
     memset(&startgrace, 0, sizeof(startgrace));
 
     gettimeofday(&lasttime, NULL);
     nextredraw = lasttime;
 
     while (1) {
+        if (interrupted) {
+            ctl->Interrupted = 1;
+            return;
+        }
+
         dt = calc_deltatime(ctl->WaitTime);
         intervaltime.tv_sec = dt / 1000000;
         intervaltime.tv_usec = dt % 1000000;
@@ -248,7 +266,12 @@ void select_loop(
                 rv = select(maxfd, (void *) &readfd, NULL, NULL,
                             &selecttime);
             }
-        } while ((rv < 0) && (errno == EINTR));
+        } while ((rv < 0) && (errno == EINTR) && !interrupted);
+
+        if (interrupted) {
+            ctl->Interrupted = 1;
+            return;
+        }
 
         if (rv < 0) {
             error(EXIT_FAILURE, errno, "Select failed");


### PR DESCRIPTION
## Summary

- handle `SIGINT` inside the select loop so display cleanup still runs
- let report mode print the measurements collected so far after `^C`
- stop processing any remaining targets after an interrupt and return the conventional `130` exit status

Fixes #4.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
- `sudo python3 ./test/cmdparse.py`
- `./mtr -r -c 100 -i 1 127.0.0.1`, sent `SIGINT`, verified partial report output and exit status `130`
- `./mtr -r -c 100 -i 1 127.0.0.1 localhost`, sent `SIGINT`, verified only the interrupted target reported and exit status `130`
