### PR TITLE
docs: clarify raw ping time units

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -238,6 +238,12 @@ Use the raw output format.  This format is better suited for
 archival of the measurement results.  It could be parsed to
 be presented into any of the other display methods.
 .IP
+Raw output uses one line per event.  Reply lines have the form
+.BR "p " "position " "round-trip-time " sequence ,
+where
+.I round-trip-time
+is an integer number of microseconds.
+.IP
 Example of the raw output format:
 .nf
 h 0 10.1.1.1


### PR DESCRIPTION
## Summary

- document the raw `p` reply line shape in the man page
- state that raw round-trip times are integer microseconds

Fixes #423.

## Validation

- `git diff --check`
- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- verified generated `mtr.8` contains the microseconds wording
- `uv run --python 3.9 --with flake8==3.9.2 --with flake8-bandit==2.1.2 --with bandit==1.7.2 --with pbr==7.0.3 python -m flake8 .`
