### PR TITLE
fix: address static analyzer findings

### DIFF
--- a/packet/probe.c
+++ b/packet/probe.c
@@ -232,9 +232,11 @@ void format_mpls_string(
             append_pos += strlen(append_pos);
         }
 
-        snprintf(append_pos, buffer_size, "%d,%d,%d,%d",
-                 mpls->label, mpls->traffic_class,
-                 mpls->bottom_of_stack, mpls->ttl);
+        snprintf(append_pos, buffer_size, "%u,%u,%u,%u",
+                 (unsigned int) mpls->label,
+                 (unsigned int) mpls->traffic_class,
+                 (unsigned int) mpls->bottom_of_stack,
+                 (unsigned int) mpls->ttl);
 
         buffer_size -= strlen(append_pos);
         append_pos += strlen(append_pos);
@@ -283,7 +285,7 @@ void respond_to_probe(
     }
 
     snprintf(response, COMMAND_BUFFER_SIZE,
-             "%d %s %s %s round-trip-time %d",
+             "%d %s %s %s round-trip-time %u",
              probe->token, result, ip_argument, ip_text, round_trip_us);
 
     if (mpls_count) {
@@ -317,7 +319,7 @@ int find_source_addr(
     const struct sockaddr_storage *destaddr)
 {
     int sock;
-    int len;
+    socklen_t len;
     struct sockaddr_storage dest_with_port;
 #ifdef __linux__
     // The Linux code needs these.

--- a/packet/probe_unix.c
+++ b/packet/probe_unix.c
@@ -563,7 +563,7 @@ void send_probe(
     char packet[PACKET_BUFFER_SIZE];
     struct probe_t *probe;
     int trytimes;
-    int packet_size;
+    int packet_size = 0;
 
     probe = alloc_probe(net_state, param->command_token);
     if (probe == NULL) {
@@ -821,7 +821,8 @@ void receive_replies_from_recv_socket(
                     packet, packet_length, &timestamp);
         } else if (icmp_hostunreach_received) {
             /* handle packet based on send socket protocol */
-            int proto, length = sizeof(int);
+            int proto;
+            socklen_t length = sizeof(proto);
 
             if (getsockopt(socket, SOL_SOCKET, SO_PROTOCOL, &proto, &length) < 0) {
                 error(EXIT_FAILURE, errno, "getsockopt SO_PROTOCOL error");
@@ -855,7 +856,7 @@ void receive_replies_from_probe_socket(
     int probe_socket;
     struct timeval zero_time;
     int err;
-    int err_length = sizeof(int);
+    socklen_t err_length = sizeof(err);
     fd_set write_set;
 
     probe_socket = probe->platform.socket;

--- a/packet/sockaddr.c
+++ b/packet/sockaddr.c
@@ -10,11 +10,13 @@ void *sockaddr_addr_offset(const void *x)
 
 	if ( ((struct sockaddr *)(x))->sa_family == AF_INET )
 	{
-		return ((void *)(x) + offsetof(struct sockaddr_in, sin_addr));
+		return (void *) ((const char *)(x) +
+			offsetof(struct sockaddr_in, sin_addr));
 	} else
 	if ( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
 	{
-		return ((void *)(x) + offsetof(struct sockaddr_in6, sin6_addr));
+		return (void *) ((const char *)(x) +
+			offsetof(struct sockaddr_in6, sin6_addr));
 	}
 
 	return NULL;
@@ -58,11 +60,13 @@ in_port_t *sockaddr_port_offset(const void *x)
 
 	if ( ((struct sockaddr *)(x))->sa_family == AF_INET )
 	{
-		return ((void *)(x) + offsetof(struct sockaddr_in, sin_port));
+		return (in_port_t *) ((const char *)(x) +
+			offsetof(struct sockaddr_in, sin_port));
 	} else
 	if ( ((struct sockaddr *)(x))->sa_family == AF_INET6 )
 	{
-		return ((void *)(x) + offsetof(struct sockaddr_in6, sin6_port));
+		return (in_port_t *) ((const char *)(x) +
+			offsetof(struct sockaddr_in6, sin6_port));
 	}
 
 	return NULL;

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -376,7 +376,8 @@ static char *get_ipinfo(
         ENTRY *found_item;
 
         DEB_syslog(LOG_INFO, ">> Search: %s", key);
-        item.key = key;;
+        item.key = key;
+        item.data = NULL;
         if ((found_item = hsearch(item, FIND))) {
             if (!(val = (*((items_t *) found_item->data))[ctl->ipinfo_no]))
                 val = (*((items_t *) found_item->data))[0];

--- a/ui/dns.c
+++ b/ui/dns.c
@@ -148,6 +148,9 @@ void dns_open(
             close(i);
         }
         infp = fdopen(todns[0], "r");
+        if (!infp) {
+            error(EXIT_FAILURE, errno, "fdopen DNS lookup pipe");
+        }
 
         while (fgets(buf, sizeof(buf), infp)) {
             ip_t host;
@@ -210,7 +213,10 @@ void dns_ack(
     struct dns_results *r;
 
     while (fgets(buf, sizeof(buf), fromdnsfp)) {
-        sscanf(buf, "%s %s", host, name);
+        if (sscanf(buf, "%1024s %1024s", host, name) != 2) {
+            error(0, 0, "dns_ack: malformed DNS lookup result");
+            continue;
+        }
 
         longipstr(host, &hostip, ctl->af);
         r = findip(ctl, &hostip);

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -186,15 +186,20 @@ static void read_from_file(
 
     FILE *in;
     char line[512];
+    int close_input;
+    int read_error;
+    int read_errno;
 
     if (!filename || strcmp(filename, "-") == 0) {
         clearerr(stdin);
         in = stdin;
+        close_input = 0;
     } else {
         in = fopen(filename, "r");
         if (!in) {
             error(EXIT_FAILURE, errno, "open %s", filename);
         }
+        close_input = 1;
     }
 
     while (fgets(line, sizeof(line), in)) {
@@ -202,12 +207,16 @@ static void read_from_file(
         append_to_names(names, name);
     }
 
-    if (ferror(in)) {
-        error(EXIT_FAILURE, errno, "ferror %s", filename);
+    read_error = ferror(in);
+    read_errno = errno;
+
+    if (close_input && fclose(in)) {
+        error(EXIT_FAILURE, errno, "close %s", filename);
     }
 
-    if (in != stdin)
-        fclose(in);
+    if (read_error) {
+        error(EXIT_FAILURE, read_errno, "ferror %s", filename);
+    }
 }
 
 /*

--- a/ui/raw.c
+++ b/ui/raw.c
@@ -75,7 +75,9 @@ void raw_rawhost(
         int k;
         for (k = 0; k < mpls->labels; k++)
             printf("m %d %lu %u %u %u\n",
-                   host, mpls->label[k], mpls->tc[k], mpls->s[k], mpls->ttl[k]);
+                   host, mpls->label[k], (unsigned int) mpls->tc[k],
+                   (unsigned int) mpls->s[k],
+                   (unsigned int) mpls->ttl[k]);
     }
 
     fflush(stdout);

--- a/ui/report.c
+++ b/ui/report.c
@@ -229,8 +229,9 @@ void report_close(
                     for (k = 0; k < mpls->labels; k++) {
                         printf
                             ("    |  |+-- [MPLS: Lbl %lu TC %u S %u TTL %u]\n",
-                             mpls->label[k], mpls->tc[k], mpls->s[k],
-                             mpls->ttl[k]);
+                             mpls->label[k], (unsigned int) mpls->tc[k],
+                             (unsigned int) mpls->s[k],
+                             (unsigned int) mpls->ttl[k]);
                     }
                 }
 
@@ -239,16 +240,18 @@ void report_close(
                     for (k = 0; k < mplss->labels && ctl->enablempls; k++) {
                         printf
                             ("    |   +-- [MPLS: Lbl %lu TC %u S %u TTL %u]\n",
-                             mplss->label[k], mplss->tc[k], mplss->s[k],
-                             mplss->ttl[k]);
+                             mplss->label[k], (unsigned int) mplss->tc[k],
+                             (unsigned int) mplss->s[k],
+                             (unsigned int) mplss->ttl[k]);
                     }
                 } else {
                     printf("    |   |-- %s\n", strlongip(ctl->af, addr2));
                     for (k = 0; k < mplss->labels && ctl->enablempls; k++) {
                         printf
                             ("    |   +-- [MPLS: Lbl %lu TC %u S %u TTL %u]\n",
-                             mplss->label[k], mplss->tc[k], mplss->s[k],
-                             mplss->ttl[k]);
+                             mplss->label[k], (unsigned int) mplss->tc[k],
+                             (unsigned int) mplss->s[k],
+                             (unsigned int) mplss->ttl[k]);
                     }
                 }
 #endif
@@ -266,8 +269,9 @@ void report_close(
             int k;
             for (k = 0; k < mpls->labels; k++) {
                 printf("    |   +-- [MPLS: Lbl %lu TC %u S %u TTL %u]\n",
-                       mpls->label[k], mpls->tc[k], mpls->s[k],
-                       mpls->ttl[k]);
+                       mpls->label[k], (unsigned int) mpls->tc[k],
+                       (unsigned int) mpls->s[k],
+                       (unsigned int) mpls->ttl[k]);
             }
         }
 #endif

--- a/ui/utils.c
+++ b/ui/utils.c
@@ -164,9 +164,12 @@ static inline int close_stream(
     const int some_pending = (__fpending(stream) != 0);
     const int prev_fail = (ferror(stream) != 0);
     const int fclose_fail = (fclose(stream) != 0);
+    const int fclose_errno = fclose_fail ? errno : 0;
 
-    if (prev_fail || (fclose_fail && (some_pending || errno != EBADF))) {
-        if (!fclose_fail && !(errno == EPIPE))
+    if (prev_fail || (fclose_fail && (some_pending || fclose_errno != EBADF))) {
+        if (fclose_fail)
+            errno = fclose_errno;
+        else
             errno = 0;
         return EOF;
     }


### PR DESCRIPTION
## Summary

This fixes a small set of actionable issues found while running static analyzers over the tree:

- check the `fdopen()` result in the DNS helper process before passing it to `fgets()`
- bound and validate DNS helper result parsing instead of using unbounded `%s`
- avoid reading `errno` on a successful `fclose()` path in `close_stream()`
- initialize the `ENTRY.data` field before an `hsearch(..., FIND)` lookup
- avoid arithmetic on `void *` in sockaddr offset helpers
- use matching unsigned format specifiers/casts for MPLS fields and round-trip time
- use `socklen_t` for `getsockname()`/`getsockopt()` length arguments
- close input files in `read_from_file()` before reporting a read error
- initialize `packet_size` defensively before the probe construction retry loop

## Analyzer runs

- `scan-build --status-bugs -o /tmp/mtr-scan-build-final make all`: no analyzer reports after this patch
- `cppcheck --enable=warning,style,performance,portability --inline-suppr --suppress=missingIncludeSystem --error-exitcode=2 .`: warning-class findings addressed; remaining error-class findings are pre-existing cppcheck limitations around queue macros / Cygwin branches / autotools `PACKAGE_VERSION`
- `clang-tidy` on the touched C files: used to catch the `socklen_t` API type mismatches; broad style/include/C11-safe-function checks are intentionally not addressed here

## Validation

- `./bootstrap.sh`
- `./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

Notes from local environment:

- `make check` without root fails raw-socket tests with `Operation not permitted`, then `probe.py` can leave a live `mtr-packet`; I stopped that run.
- `sudo python3 ./test/param.py` currently times out waiting for `mtr-packet-listen` to exit locally.
- `sudo python3 ./test/probe.py` currently has one local failure in `test_exhaust_probes`.
- local `flake8 .` reports pre-existing unused `typing` imports in `test/mtrpacket.py`.

Tracked issues closed: none. This is analyzer-driven maintenance.
