### PR TITLE
fix(split): avoid truncating cached output lines

### DIFF
--- a/ui/split.c
+++ b/ui/split.c
@@ -55,7 +55,7 @@
 
 /* There is 256 hops max in the IP header (coded with a byte) */
 #define MAX_LINE_COUNT 256
-#define MAX_LINE_SIZE  256
+#define MAX_LINE_SIZE  2048
 
 static char Lines[MAX_LINE_COUNT][MAX_LINE_SIZE];
 static int LineCount;
@@ -114,7 +114,7 @@ void split_redraw(
 	    // something changed, so we print it.
             printf("%d %s\n", at + 1, newLine);
             fflush(stdout);
-            xstrncpy(Lines[at], newLine, MAX_LINE_SIZE);
+            memcpy(Lines[at], newLine, MAX_LINE_SIZE);
             if (LineCount < (at + 1)) {
                 LineCount = at + 1;
             }


### PR DESCRIPTION
## Summary

This addresses the GCC truncation warnings in `ui/split.c` by:

- increasing the internal split output line cache from 256 bytes to 2048 bytes
- copying the already `snprintf()`-bounded scratch line into the same-sized cache with `memcpy()`

This keeps the change small and avoids changing the split output format. The cache is still bounded by the IPv4 hop-count limit: 256 cached lines.

## Validation

- `make clean >/tmp/mtr-make-clean.log && make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

Tracked issues closed: none. This is compiler-warning cleanup found during the analyzer pass.
