### PR TITLE
fix(mpls): print stack flag without suffix

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -486,8 +486,9 @@ static void mtr_curses_hosts(
 
             for (k = 0; k < mpls->labels && ctl->enablempls; k++) {
                 printw("\n    [MPLS: Lbl %lu TC %u S %u TTL %u]",
-                       mpls->label[k], mpls->tc[k], mpls->s[k],
-                       mpls->ttl[k]);
+                       mpls->label[k], (unsigned int) mpls->tc[k],
+                       (unsigned int) mpls->s[k],
+                       (unsigned int) mpls->ttl[k]);
             }
 
             /* Multi path */
@@ -517,8 +518,9 @@ static void mtr_curses_hosts(
                 }
                 for (k = 0; k < mplss->labels && ctl->enablempls; k++) {
                     printw("\n    [MPLS: Lbl %lu TC %u S %u TTL %u]",
-                           mplss->label[k], mplss->tc[k], mplss->s[k],
-                           mplss->ttl[k]);
+                           mplss->label[k], (unsigned int) mplss->tc[k],
+                           (unsigned int) mplss->s[k],
+                           (unsigned int) mplss->ttl[k]);
                 }
                 attroff(A_BOLD);
             }

--- a/ui/report.c
+++ b/ui/report.c
@@ -82,8 +82,9 @@ static void print_mpls(
 {
     int k;
     for (k = 0; k < mpls->labels; k++)
-        printf("       [MPLS: Lbl %lu TC %u S %cu TTL %u]\n",
-               mpls->label[k], mpls->tc[k], mpls->s[k], mpls->ttl[k]);
+        printf("       [MPLS: Lbl %lu TC %u S %u TTL %u]\n",
+               mpls->label[k], (unsigned int) mpls->tc[k],
+               (unsigned int) mpls->s[k], (unsigned int) mpls->ttl[k]);
 }
 #endif
 


### PR DESCRIPTION
## Summary

This fixes a small MPLS report formatting issue found while following up on analyzer/format warnings.

The IP-info report helper used `%cu` for the bottom-of-stack field, which can print an extra literal `u` after the value. The other MPLS output paths print this field as an unsigned numeric flag, so this switches the helper to `%u` and casts the small integer fields explicitly.

The curses MPLS output gets the same explicit casts for consistency with the report/raw output format handling.

## Validation

- `make clean >/tmp/mtr-make-clean.log && make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

Tracked issues closed: none. This is static-analysis/format follow-up cleanup.
