### PR TITLE
fix(gtk): bound formatter output

### DIFF
--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -356,7 +356,7 @@ static void float_formatter(
     gfloat f;
     gchar text[64];
     gtk_tree_model_get(tree_model, iter, POINTER_TO_INT(data), &f, -1);
-    sprintf(text, "%.2f", f);
+    snprintf(text, sizeof(text), "%.2f", f);
     g_object_set(cell, "text", text, NULL);
 }
 
@@ -370,7 +370,7 @@ static void percent_formatter(
     gfloat f;
     gchar text[64];
     gtk_tree_model_get(tree_model, iter, POINTER_TO_INT(data), &f, -1);
-    sprintf(text, "%.1f%%", f);
+    snprintf(text, sizeof(text), "%.1f%%", f);
     g_object_set(cell, "text", text, NULL);
 }
 


### PR DESCRIPTION
## Summary

Replace the remaining GTK formatter `sprintf()` calls with `snprintf()` using the destination buffer size.

The formatted values are small, but this keeps the GTK formatting code consistent with the rest of the codebase and removes the unbounded writes flagged during the analyzer/string-safety pass.

## Validation

- `cppcheck --enable=warning --inline-suppr --suppress=missingIncludeSystem --error-exitcode=2 ui/gtk.c`
- `make clean >/tmp/mtr-make-clean.log && make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

Tracked issues closed: none. This is analyzer-driven cleanup.
