### PR TITLE
fix(cmdpipe): bound packet path fallback

### DIFF
--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -241,8 +241,7 @@ void execute_packet_child(
     /*
        Then try to find it where WE were executed from.
      */
-    strncpy (buf, myname, 240);
-    strcat (buf, "-packet");
+    snprintf(buf, sizeof(buf), "%s-packet", myname);
     mtr_packet_path = buf;
     execl(mtr_packet_path, "mtr-packet", (char *) NULL);
 


### PR DESCRIPTION
## Summary

Replace the `strncpy()` + `strcat()` fallback path construction for `mtr-packet` with a single bounded `snprintf()`.

This keeps the same fallback behavior while avoiding a manually chosen copy length and guaranteeing null termination for the local buffer.

## Validation

- `cppcheck --enable=warning --inline-suppr --suppress=missingIncludeSystem --error-exitcode=2 ui/cmdpipe.c`
- `make clean >/tmp/mtr-make-clean.log && make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

Tracked issues closed: none. This is analyzer/string-safety cleanup.
