### PR TITLE
fix(cmdpipe): bound probe command appends

### DIFF
--- a/packet/cmdparse.h
+++ b/packet/cmdparse.h
@@ -24,6 +24,28 @@ enum {
     MAX_COMMAND_TOKENS = MAX_COMMAND_ARGUMENTS * 2 + 2
 };
 
+#define COMMAND_NAME_SEND_PROBE "send-probe"
+
+#define COMMAND_ARG_BIT_PATTERN "bit-pattern"
+#define COMMAND_ARG_IP4 "ip-4"
+#define COMMAND_ARG_IP6 "ip-6"
+#define COMMAND_ARG_LOCAL_DEVICE "local-device"
+#define COMMAND_ARG_LOCAL_IP4 "local-ip-4"
+#define COMMAND_ARG_LOCAL_IP6 "local-ip-6"
+#define COMMAND_ARG_LOCAL_PORT "local-port"
+#define COMMAND_ARG_MARK "mark"
+#define COMMAND_ARG_PORT "port"
+#define COMMAND_ARG_PROTOCOL "protocol"
+#define COMMAND_ARG_SIZE "size"
+#define COMMAND_ARG_TIMEOUT "timeout"
+#define COMMAND_ARG_TOS "tos"
+#define COMMAND_ARG_TTL "ttl"
+
+#define COMMAND_PROTOCOL_ICMP "icmp"
+#define COMMAND_PROTOCOL_SCTP "sctp"
+#define COMMAND_PROTOCOL_TCP "tcp"
+#define COMMAND_PROTOCOL_UDP "udp"
+
 /*  Parsed commands, or command replies, ready for semantic interpretation  */
 struct command_t {
     /*  A unique value for matching command requests with replies  */

--- a/packet/command.c
+++ b/packet/command.c
@@ -98,37 +98,37 @@ const char *check_support(
         return PACKAGE_VERSION;
     }
 
-    if (!strcmp(feature, "ip-4")) {
+    if (!strcmp(feature, COMMAND_ARG_IP4)) {
         return check_ip_version_support(net_state, 4);
     }
 
-    if (!strcmp(feature, "ip-6")) {
+    if (!strcmp(feature, COMMAND_ARG_IP6)) {
         return check_ip_version_support(net_state, 6);
     }
 
-    if (!strcmp(feature, "send-probe")) {
+    if (!strcmp(feature, COMMAND_NAME_SEND_PROBE)) {
         return "ok";
     }
 
-    if (!strcmp(feature, "icmp")) {
+    if (!strcmp(feature, COMMAND_PROTOCOL_ICMP)) {
         return check_protocol_support(net_state, IPPROTO_ICMP);
     }
 
-    if (!strcmp(feature, "udp")) {
+    if (!strcmp(feature, COMMAND_PROTOCOL_UDP)) {
         return check_protocol_support(net_state, IPPROTO_UDP);
     }
 
-    if (!strcmp(feature, "tcp")) {
+    if (!strcmp(feature, COMMAND_PROTOCOL_TCP)) {
         return check_protocol_support(net_state, IPPROTO_TCP);
     }
 #ifdef IPPROTO_SCTP
-    if (!strcmp(feature, "sctp")) {
+    if (!strcmp(feature, COMMAND_PROTOCOL_SCTP)) {
         return check_protocol_support(net_state, IPPROTO_SCTP);
     }
 #endif
 
 #ifdef SO_MARK
-    if (!strcmp(feature, "mark")) {
+    if (!strcmp(feature, COMMAND_ARG_MARK)) {
         return "ok";
     }
 #endif
@@ -168,42 +168,42 @@ bool decode_probe_argument(
     char *endstr = NULL;
 
     /*  Pass IPv4 addresses as string values  */
-    if (!strcmp(name, "ip-4")) {
+    if (!strcmp(name, COMMAND_ARG_IP4)) {
         param->ip_version = 4;
         param->remote_address = value;
     }
 
     /*  IPv6 address  */
-    if (!strcmp(name, "ip-6")) {
+    if (!strcmp(name, COMMAND_ARG_IP6)) {
         param->ip_version = 6;
         param->remote_address = value;
     }
 
     /*  IPv4 address to send from  */
-    if (!strcmp(name, "local-ip-4")) {
+    if (!strcmp(name, COMMAND_ARG_LOCAL_IP4)) {
         param->local_address = value;
     }
 
     /*  IPv6 address to send from  */
-    if (!strcmp(name, "local-ip-6")) {
+    if (!strcmp(name, COMMAND_ARG_LOCAL_IP6)) {
         param->local_address = value;
     }
 
     /*  Device name to send from  */
-    if (!strcmp(name, "local-device")) {
+    if (!strcmp(name, COMMAND_ARG_LOCAL_DEVICE)) {
         param->local_device = value;
     }
 
     /*  Protocol for the probe  */
-    if (!strcmp(name, "protocol")) {
-        if (!strcmp(value, "icmp")) {
+    if (!strcmp(name, COMMAND_ARG_PROTOCOL)) {
+        if (!strcmp(value, COMMAND_PROTOCOL_ICMP)) {
             param->protocol = IPPROTO_ICMP;
-        } else if (!strcmp(value, "udp")) {
+        } else if (!strcmp(value, COMMAND_PROTOCOL_UDP)) {
             param->protocol = IPPROTO_UDP;
-        } else if (!strcmp(value, "tcp")) {
+        } else if (!strcmp(value, COMMAND_PROTOCOL_TCP)) {
             param->protocol = IPPROTO_TCP;
 #ifdef IPPROTO_SCTP
-        } else if (!strcmp(value, "sctp")) {
+        } else if (!strcmp(value, COMMAND_PROTOCOL_SCTP)) {
             param->protocol = IPPROTO_SCTP;
 #endif
         } else {
@@ -212,7 +212,7 @@ bool decode_probe_argument(
     }
 
     /*  Destination port for the probe  */
-    if (!strcmp(name, "port")) {
+    if (!strcmp(name, COMMAND_ARG_PORT)) {
         param->dest_port = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -220,7 +220,7 @@ bool decode_probe_argument(
     }
 
     /*  The local port to send UDP probes from  */
-    if (!strcmp(name, "local-port")) {
+    if (!strcmp(name, COMMAND_ARG_LOCAL_PORT)) {
         param->local_port = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -237,7 +237,7 @@ bool decode_probe_argument(
     }
 
     /*  The "type of service" field for the IP header  */
-    if (!strcmp(name, "tos")) {
+    if (!strcmp(name, COMMAND_ARG_TOS)) {
         param->type_of_service = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -245,7 +245,7 @@ bool decode_probe_argument(
     }
 
     /*  The Linux packet mark for mark-based routing  */
-    if (!strcmp(name, "mark")) {
+    if (!strcmp(name, COMMAND_ARG_MARK)) {
         param->routing_mark = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -253,7 +253,7 @@ bool decode_probe_argument(
     }
 
     /*  The size of the packet (including headers)  */
-    if (!strcmp(name, "size")) {
+    if (!strcmp(name, COMMAND_ARG_SIZE)) {
         param->packet_size = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -261,7 +261,7 @@ bool decode_probe_argument(
     }
 
     /*  The packet's bytes will be filled with this value  */
-    if (!strcmp(name, "bit-pattern")) {
+    if (!strcmp(name, COMMAND_ARG_BIT_PATTERN)) {
         param->bit_pattern = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -269,7 +269,7 @@ bool decode_probe_argument(
     }
 
     /*  Time-to-live values  */
-    if (!strcmp(name, "ttl")) {
+    if (!strcmp(name, COMMAND_ARG_TTL)) {
         param->ttl = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -277,7 +277,7 @@ bool decode_probe_argument(
     }
 
     /*  Number of seconds to wait for a reply  */
-    if (!strcmp(name, "timeout")) {
+    if (!strcmp(name, COMMAND_ARG_TIMEOUT)) {
         param->timeout = strtol(value, &endstr, 10);
         if (*endstr != 0) {
             return false;
@@ -364,7 +364,7 @@ void dispatch_command(
 {
     if (!strcmp(command->command_name, "check-support")) {
         check_support_command(command, net_state);
-    } else if (!strcmp(command->command_name, "send-probe")) {
+    } else if (!strcmp(command->command_name, COMMAND_NAME_SEND_PROBE)) {
         send_probe_command(command, net_state);
     } else {
         /*  For unrecognized commands, respond with an error  */

--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -150,6 +151,27 @@ int check_feature(
 }
 
 
+static
+const char *packet_protocol_name(
+    int protocol)
+{
+    switch (protocol) {
+    case IPPROTO_ICMP:
+        return COMMAND_PROTOCOL_ICMP;
+    case IPPROTO_UDP:
+        return COMMAND_PROTOCOL_UDP;
+    case IPPROTO_TCP:
+        return COMMAND_PROTOCOL_TCP;
+#ifdef HAS_SCTP
+    case IPPROTO_SCTP:
+        return COMMAND_PROTOCOL_SCTP;
+#endif
+    default:
+        return NULL;
+    }
+}
+
+
 /*
     Check the protocol selected against the mtr-packet we are using.
     Returns zero if everything is fine, or -1 with errno for either
@@ -160,13 +182,15 @@ int check_packet_features(
     struct mtr_ctl *ctl,
     struct packet_command_pipe_t *cmdpipe)
 {
+    const char *protocol;
+
     /*  Check the IP protocol version  */
     if (ctl->af == AF_INET6) {
-        if (check_feature(ctl, cmdpipe, "ip-6")) {
+        if (check_feature(ctl, cmdpipe, COMMAND_ARG_IP6)) {
             return -1;
         }
     } else if (ctl->af == AF_INET) {
-        if (check_feature(ctl, cmdpipe, "ip-4")) {
+        if (check_feature(ctl, cmdpipe, COMMAND_ARG_IP4)) {
             return -1;
         }
     } else {
@@ -175,32 +199,18 @@ int check_packet_features(
     }
 
     /*  Check the transport protocol  */
-    if (ctl->mtrtype == IPPROTO_ICMP) {
-        if (check_feature(ctl, cmdpipe, "icmp")) {
-            return -1;
-        }
-    } else if (ctl->mtrtype == IPPROTO_UDP) {
-        if (check_feature(ctl, cmdpipe, "udp")) {
-            return -1;
-        }
-    } else if (ctl->mtrtype == IPPROTO_TCP) {
-        if (check_feature(ctl, cmdpipe, "tcp")) {
-            return -1;
-        }
-#ifdef HAS_SCTP
-    } else if (ctl->mtrtype == IPPROTO_SCTP) {
-        if (check_feature(ctl, cmdpipe, "sctp")) {
-            return -1;
-        }
-#endif
-    } else {
+    protocol = packet_protocol_name(ctl->mtrtype);
+    if (protocol == NULL) {
         errno = EINVAL;
+        return -1;
+    }
+    if (check_feature(ctl, cmdpipe, protocol)) {
         return -1;
     }
 
 #ifdef SO_MARK
     if (ctl->mark) {
-        if (check_feature(ctl, cmdpipe, "mark")) {
+        if (check_feature(ctl, cmdpipe, COMMAND_ARG_MARK)) {
             return -1;
         }
     }
@@ -338,7 +348,7 @@ int open_command_pipe(
            Check that we can communicate with the client.  If we failed to
            execute the mtr-packet binary, we will discover that here.
          */
-        if (check_feature(ctl, cmdpipe, "send-probe")) {
+        if (check_feature(ctl, cmdpipe, COMMAND_NAME_SEND_PROBE)) {
             fail_packet_startup(errno);
         }
 
@@ -386,7 +396,7 @@ void construct_base_command(
     char local_ip_string[INET6_ADDRSTRLEN];
     const char *ip_type;
     const char *local_ip_type;
-    const char *protocol = NULL;
+    const char *protocol;
 
     /*  Convert the remote IP address to a string  */
     if (inet_ntop(ctl->af, address, ip_string, INET6_ADDRSTRLEN) == NULL) {
@@ -403,67 +413,66 @@ void construct_base_command(
     }
 
     if (ctl->af == AF_INET6) {
-        ip_type = "ip-6";
-        local_ip_type = "local-ip-6";
+        ip_type = COMMAND_ARG_IP6;
+        local_ip_type = COMMAND_ARG_LOCAL_IP6;
     } else {
-        ip_type = "ip-4";
-        local_ip_type = "local-ip-4";
+        ip_type = COMMAND_ARG_IP4;
+        local_ip_type = COMMAND_ARG_LOCAL_IP4;
     }
 
-    if (ctl->mtrtype == IPPROTO_ICMP) {
-        protocol = "icmp";
-    } else if (ctl->mtrtype == IPPROTO_UDP) {
-        protocol = "udp";
-    } else if (ctl->mtrtype == IPPROTO_TCP) {
-        protocol = "tcp";
-#ifdef HAS_SCTP
-    } else if (ctl->mtrtype == IPPROTO_SCTP) {
-        protocol = "sctp";
-#endif
-    } else {
+    protocol = packet_protocol_name(ctl->mtrtype);
+    if (protocol == NULL) {
         display_close(ctl);
         error(EXIT_FAILURE, 0,
               "protocol unsupported by mtr-packet interface");
     }
 
-    snprintf(command, buffer_size,
-             "%d send-probe %s %s %s %s protocol %s",
-             command_token,
-             ip_type, ip_string, local_ip_type, local_ip_string, protocol);
+    if (snprintf(command, buffer_size,
+                 "%d " COMMAND_NAME_SEND_PROBE " %s %s %s %s "
+                 COMMAND_ARG_PROTOCOL " %s",
+                 command_token, ip_type, ip_string, local_ip_type,
+                 local_ip_string, protocol) >= buffer_size) {
+        display_close(ctl);
+        error(EXIT_FAILURE, 0, "mtr-packet command too long");
+    }
 }
 
 
-/*  Append an argument to the "send-probe" command string  */
+/*  Append a formatted fragment to the "send-probe" command string  */
 static
-void append_command_argument(
+void append_command_format(
+    struct mtr_ctl *ctl,
     char *command,
     int buffer_size,
-    char *name,
-    int value)
+    const char *description,
+    const char *format,
+    ...)
 {
-    char argument[COMMAND_BUFFER_SIZE];
-    int remaining_size;
+    size_t command_length;
+    size_t remaining_size;
+    int written;
+    va_list args;
 
-    remaining_size = buffer_size - strlen(command) - 1;
+    command_length = strlen(command);
+    if (command_length >= (size_t) buffer_size) {
+        display_close(ctl);
+        error(EXIT_FAILURE, 0,
+              "mtr-packet command too long before appending %s",
+              description);
+    }
 
-    snprintf(argument, buffer_size, " %s %d", name, value);
-    strncat(command, argument, remaining_size);
-}
+    remaining_size = (size_t) buffer_size - command_length;
 
-static
-void append_command_string_argument(
-    char *command,
-    int buffer_size,
-    char *name,
-    char *value)
-{
-    char argument[COMMAND_BUFFER_SIZE];
-    int remaining_size;
-
-    remaining_size = buffer_size - strlen(command) - 1;
-
-    snprintf(argument, buffer_size, " %s %s", name, value);
-    strncat(command, argument, remaining_size);
+    va_start(args, format);
+    written = vsnprintf(command + command_length, remaining_size, format,
+                        args);
+    va_end(args);
+    if (written < 0 || (size_t) written >= remaining_size) {
+        display_close(ctl);
+        error(EXIT_FAILURE, 0,
+              "mtr-packet command too long while appending %s",
+              description);
+    }
 }
 
 
@@ -478,50 +487,60 @@ void send_probe_command(
     int time_to_live)
 {
     char command[COMMAND_BUFFER_SIZE];
-    int remaining_size;
     int timeout;
 
     construct_base_command(ctl, command, COMMAND_BUFFER_SIZE, sequence,
                            address, localaddress);
 
-    append_command_argument(command, COMMAND_BUFFER_SIZE, "size",
-                            packet_size);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                          COMMAND_ARG_SIZE,
+                          " " COMMAND_ARG_SIZE " %d", packet_size);
 
-    append_command_argument(command, COMMAND_BUFFER_SIZE, "bit-pattern",
-                            ctl->bitpattern);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                          COMMAND_ARG_BIT_PATTERN,
+                          " " COMMAND_ARG_BIT_PATTERN " %d",
+                          ctl->bitpattern);
 
-    append_command_argument(command, COMMAND_BUFFER_SIZE, "tos", ctl->tos);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                          COMMAND_ARG_TOS,
+                          " " COMMAND_ARG_TOS " %d", ctl->tos);
 
-    append_command_argument(command, COMMAND_BUFFER_SIZE, "ttl",
-                            time_to_live);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                          COMMAND_ARG_TTL,
+                          " " COMMAND_ARG_TTL " %d", time_to_live);
 
     timeout = ctl->probe_timeout / 1000000;
-    append_command_argument(command, COMMAND_BUFFER_SIZE, "timeout",
-                            timeout);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                          COMMAND_ARG_TIMEOUT,
+                          " " COMMAND_ARG_TIMEOUT " %d", timeout);
 
     if (ctl->remoteport) {
-        append_command_argument(command, COMMAND_BUFFER_SIZE, "port",
-                                ctl->remoteport);
+        append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                              COMMAND_ARG_PORT,
+                              " " COMMAND_ARG_PORT " %d", ctl->remoteport);
     }
 
     if (ctl->localport) {
-        append_command_argument(command, COMMAND_BUFFER_SIZE, "local-port",
-                                ctl->localport);
+        append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                              COMMAND_ARG_LOCAL_PORT,
+                              " " COMMAND_ARG_LOCAL_PORT " %d",
+                              ctl->localport);
     }
 #ifdef SO_MARK
     if (ctl->mark) {
-        append_command_argument(command, COMMAND_BUFFER_SIZE, "mark",
-                                ctl->mark);
+        append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                              COMMAND_ARG_MARK,
+                              " " COMMAND_ARG_MARK " %d", ctl->mark);
     }
 #endif
 
     if (ctl->InterfaceName) {
-        append_command_string_argument(command, COMMAND_BUFFER_SIZE,
-                                       "local-device", ctl->InterfaceName);
+        append_command_format(ctl, command, COMMAND_BUFFER_SIZE,
+                              COMMAND_ARG_LOCAL_DEVICE,
+                              " " COMMAND_ARG_LOCAL_DEVICE " %s",
+                              ctl->InterfaceName);
     }
-
-    remaining_size = COMMAND_BUFFER_SIZE - strlen(command) - 1;
-    strncat(command, "\n", remaining_size);
+    append_command_format(ctl, command, COMMAND_BUFFER_SIZE, "newline", "\n");
 
     /*  Send a probe using the mtr-packet subprocess  */
     if (write(cmdpipe->write_fd, command, strlen(command)) == -1) {
@@ -630,14 +649,14 @@ bool parse_reply_arguments(
 
         if (ctl->af == AF_INET6) {
             /*  IPv6 address of the responding host  */
-            if (!strcmp(arg_name, "ip-6")) {
+            if (!strcmp(arg_name, COMMAND_ARG_IP6)) {
                 if (inet_pton(AF_INET6, arg_value, fromaddress)) {
                     found_ip = true;
                 }
             }
         } else {
             /*  IPv4 address of the responding host  */
-            if (!strcmp(arg_name, "ip-4")) {
+            if (!strcmp(arg_name, COMMAND_ARG_IP4)) {
                 if (inet_pton(AF_INET, arg_value, fromaddress)) {
                     found_ip = true;
                 }


### PR DESCRIPTION
## Summary

Build appended `send-probe` command fragments directly into the remaining command buffer through one checked `append_command_format()` helper.

This removes the temporary argument buffers plus `strncat()` pattern, avoids converting a negative remaining length into a large unsigned append size if the command is already at the buffer boundary, and turns command-buffer truncation into a clear `mtr-packet command too long ...` failure instead of silently sending a partial command to `mtr-packet`.

The `mtr-packet` command names, argument names, and protocol names used by this path are now defined in `packet/cmdparse.h` so the UI command builder does not keep repeating wire-format string literals.

The command format is unchanged when it fits.

## Validation

- `make -j$(nproc)`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`
- `./mtr -r -c 1 127.0.0.1`

Tracked issues closed: none. This is analyzer/string-safety cleanup.
