### PR TITLE
fix(cygwin): initialize ICMP reply address

### DIFF
--- a/packet/probe_cygwin.c
+++ b/packet/probe_cygwin.c
@@ -273,6 +273,8 @@ void WINAPI on_icmp_reply(
     ICMP_ECHO_REPLY *reply4;
     ICMPV6_ECHO_REPLY *reply6;
 
+    remote_addr = request->dest_sockaddr;
+
     if (request->ip_version == 6) {
         reply6 = request->reply6;
         reply_count = Icmp6ParseReplies(reply6, sizeof(ICMPV6_ECHO_REPLY));


### PR DESCRIPTION
## Summary

Initialize the Cygwin ICMP completion `remote_addr` from the probed destination before parsing ICMP.DLL replies.

When ICMP.DLL returns no parsed reply, the callback still stores `remote_addr` in the request. That value is normally unused on the error path, but leaving it uninitialized is unnecessary and is reported by cppcheck.

Real parsed IPv4/IPv6 replies still overwrite the default with the address reported by ICMP.DLL.

## Validation

- `cppcheck --enable=warning --inline-suppr --suppress=missingIncludeSystem --error-exitcode=2 packet/probe_cygwin.c`
- `make clean >/tmp/mtr-make-clean.log && make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`

I could not compile the Cygwin-specific object locally; this is a targeted analyzer cleanup for that path.

Tracked issues closed: none. This is analyzer-driven cleanup.
