### PR TITLE
fix(cmdpipe): clarify mtr-packet startup failures

### DIFF
--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -100,10 +100,15 @@ int send_synchronous_command(
     if (read_length < 0) {
         return -1;
     }
+    if (read_length == 0) {
+        errno = EPIPE;
+        return -1;
+    }
 
     /*  Parse the query reply  */
     reply[read_length] = 0;
     if (parse_command(result, reply)) {
+        errno = EPROTO;
         return -1;
     }
 
@@ -202,6 +207,17 @@ int check_packet_features(
 #endif
 
     return 0;
+}
+
+
+static
+void fail_packet_startup(
+    int saved_errno)
+{
+    error(0, saved_errno, "Failure to start mtr-packet");
+    error(EXIT_FAILURE, 0,
+          "mtr-packet did not answer the startup check; "
+          "check that it is installed and allowed to open probe sockets");
 }
 
 
@@ -313,7 +329,7 @@ int open_command_pipe(
            execute the mtr-packet binary, we will discover that here.
          */
         if (check_feature(ctl, cmdpipe, "send-probe")) {
-            error(EXIT_FAILURE, errno, "Failure to start mtr-packet");
+            fail_packet_startup(errno);
         }
 
         if (check_packet_features(ctl, cmdpipe)) {


### PR DESCRIPTION
## Summary

This follows up on #562 in the shape requested in review: keep the original system-level errors from `mtr-packet`, but make the parent `mtr` diagnostic less misleading when the packet helper exits before answering the startup check.

Instead of replacing the low-level errors with a guessed "run as root" message, `mtr` now:

- reports EOF from the packet helper as `EPIPE`
- reports malformed startup replies as `EPROTO`
- prints a neutral hint to check the `mtr-packet` installation and socket permissions

Supersedes #562.

Credit note: #562 by Alexander Momchilov identified the confusing packet-helper startup failure. This PR keeps the real low-level errors as requested in review, so it is not a direct cherry-pick of the rejected root-only check.

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`
- `./mtr --help && ./mtr --version`
- `./mtr -r -c 1 127.0.0.1`
- `MTR_PACKET=/bin/false ./mtr -r -c 1 127.0.0.1`
- `MTR_PACKET=/bin/echo ./mtr -r -c 1 127.0.0.1`

