### PR TITLE
feat(curses): add configurable stripchart scale

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -29,6 +29,9 @@ mtr \- a network diagnostic tool
 .BI \--displaymode \ MODE\c
 ]
 [\c
+.BI \--scale \ SCALE\c
+]
+[\c
 .B \-\-raw\c
 ]
 [\c
@@ -221,6 +224,19 @@ Use this option to select the initial display mode: 0 (default)
 selects statistics, 1 selects the stripchart without latency
 information, and 2 selects the stripchart with latency
 information.
+.TP
+.B -\-scale \fISCALE
+Use this option to select fixed latency thresholds for the stripchart
+display modes.
+.I SCALE
+can be
+.BR fast ,
+.BR average ,
+.BR slow ,
+or nine strictly increasing millisecond thresholds separated by colons,
+for example
+.BR 5:15:25:35:45:55:101:200:400 .
+Without this option, the stripchart keeps using the dynamic scale.
 .TP
 .B \-g\fR, \fB\-\-gtk
 Use this option to force

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -20,6 +20,7 @@
 
 #include "mtr.h"
 
+#include <limits.h>
 #include <locale.h>
 #ifdef __CYGWIN__
 #include <windows.h>
@@ -74,27 +75,29 @@
 #include "utils.h"
 
 
-enum { NUM_FACTORS = 8 };
+enum { NUM_FACTORS = MTR_SCALE_FACTORS };
 static double factors[NUM_FACTORS];
 static int scale[NUM_FACTORS];
 static char block_map[NUM_FACTORS];
 #ifdef WITH_BRAILLE_DISPLAY
 static const wchar_t *braille_map[NUM_FACTORS] = {
-    L"⣀", L"⣀", L"⣤", L"⣤", L"⣶", L"⣶", L"⣿", L"⣿"
+    L"⣀", L"⣀", L"⣤", L"⣤", L"⣦", L"⣦", L"⣶", L"⣶", L"⣿", L"⣿"
 };
 #endif
 
 enum { black = 1, red, green, yellow, blue, magenta, cyan, white };
 static const int block_col[NUM_FACTORS + 1] = {
     COLOR_PAIR(red) | A_BOLD,
-    A_NORMAL,
-    COLOR_PAIR(green),
+    COLOR_PAIR(green) | A_BOLD,
+    COLOR_PAIR(green) | A_BOLD,
     COLOR_PAIR(green) | A_BOLD,
     COLOR_PAIR(yellow) | A_BOLD,
+    COLOR_PAIR(yellow) | A_BOLD,
     COLOR_PAIR(magenta) | A_BOLD,
-    COLOR_PAIR(magenta),
+    COLOR_PAIR(red) | A_BOLD,
+    COLOR_PAIR(red) | A_BOLD,
     COLOR_PAIR(red),
-    COLOR_PAIR(red) | A_BOLD
+    COLOR_PAIR(red)
 };
 
 static void pwcenter(
@@ -546,6 +549,14 @@ static void mtr_gen_scale(
     for (i = 0; i < NUM_FACTORS; i++) {
         scale[i] = 0;
     }
+    if (ctl->fixed_scale) {
+        for (i = 0; i < MTR_SCALE_THRESHOLDS; i++) {
+            scale[i] = ctl->scale[i];
+        }
+        scale[NUM_FACTORS - 1] = INT_MAX;
+        return;
+    }
+
     max = net_max(ctl);
     for (at = ctl->display_offset; at < max; at++) {
         saved = net_saved_pings(at);
@@ -579,7 +590,7 @@ static void mtr_curses_init(
     }
 
     /* Initialize block_map.  The block_split is always smaller than 9 */
-    block_split = (NUM_FACTORS - 2) / 2;
+    block_split = NUM_FACTORS / 2;
     for (i = 1; i <= block_split; i++) {
         block_map[i] = '0' + i;
     }

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -136,6 +136,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs(" -t, --curses                     use curses terminal interface\n", out);       
 #endif       
     fputs("     --displaymode MODE           select initial display mode\n", out);       
+    fputs("     --scale SCALE                set stripchart scale thresholds\n", out);
 #ifdef HAVE_GTK       
     fputs(" -g, --gtk                        use GTK+ xwindow interface\n", out);
 #endif       
@@ -285,6 +286,87 @@ static void init_fld_options(
 }
 
 
+static void set_fixed_scale(
+    struct mtr_ctl *ctl,
+    const int *thresholds)
+{
+    int i;
+
+    for (i = 0; i < MTR_SCALE_THRESHOLDS; i++) {
+        ctl->scale[i] = thresholds[i] * 1000;
+    }
+    ctl->fixed_scale = 1;
+}
+
+
+static void parse_scale(
+    struct mtr_ctl *ctl,
+    const char *scale_arg)
+{
+    static const int fast_scale[MTR_SCALE_THRESHOLDS] = {
+        1, 2, 3, 4, 5, 10, 20, 40, 80
+    };
+    static const int average_scale[MTR_SCALE_THRESHOLDS] = {
+        5, 15, 25, 35, 45, 55, 101, 200, 400
+    };
+    static const int slow_scale[MTR_SCALE_THRESHOLDS] = {
+        50, 100, 150, 200, 300, 500, 750, 1000, 2000
+    };
+    const char *cursor = scale_arg;
+    int thresholds[MTR_SCALE_THRESHOLDS];
+    int previous = -1;
+    int i;
+
+    if (!strcmp(scale_arg, "fast")) {
+        set_fixed_scale(ctl, fast_scale);
+        return;
+    }
+    if (!strcmp(scale_arg, "average")) {
+        set_fixed_scale(ctl, average_scale);
+        return;
+    }
+    if (!strcmp(scale_arg, "slow")) {
+        set_fixed_scale(ctl, slow_scale);
+        return;
+    }
+
+    for (i = 0; i < MTR_SCALE_THRESHOLDS; i++) {
+        char *end;
+        long threshold;
+
+        errno = 0;
+        threshold = strtol(cursor, &end, 10);
+        if (cursor == end || errno || threshold < 0 ||
+            threshold > INT_MAX / 1000) {
+            error(EXIT_FAILURE, 0, "invalid scale threshold: %s", scale_arg);
+        }
+        if (threshold <= previous) {
+            error(EXIT_FAILURE, 0,
+                  "scale thresholds must be strictly increasing: %s",
+                  scale_arg);
+        }
+
+        thresholds[i] = threshold;
+        previous = threshold;
+
+        if (i == MTR_SCALE_THRESHOLDS - 1) {
+            if (*end) {
+                error(EXIT_FAILURE, 0,
+                      "scale expects %d thresholds: %s",
+                      MTR_SCALE_THRESHOLDS, scale_arg);
+            }
+        } else if (*end != ':') {
+            error(EXIT_FAILURE, 0,
+                  "scale expects %d colon-separated thresholds: %s",
+                  MTR_SCALE_THRESHOLDS, scale_arg);
+        }
+        cursor = end + 1;
+    }
+
+    set_fixed_scale(ctl, thresholds);
+}
+
+
 static void parse_arg(
     struct mtr_ctl *ctl,
     names_t ** names,
@@ -301,9 +383,10 @@ static void parse_arg(
      */
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
-        OPT_IPINFO4 = CHAR_MAX + 2,
+        OPT_SCALE = CHAR_MAX + 2,
+        OPT_IPINFO4 = CHAR_MAX + 3,
 #ifdef ENABLE_IPV6
-        OPT_IPINFO6 = CHAR_MAX + 3,
+        OPT_IPINFO6 = CHAR_MAX + 4,
 #endif /* ifdef ENABLE_IPV6 */
     };
     static const struct option long_options[] = {
@@ -332,6 +415,7 @@ static void parse_arg(
         {"json", 0, NULL, 'j'},
 #endif
         {"displaymode", 1, NULL, OPT_DISPLAYMODE},
+        {"scale", 1, NULL, OPT_SCALE},
         {"split", 0, NULL, 'p'},        /* BL */
         /* maybe above should change to -d 'x' */
 
@@ -446,6 +530,9 @@ static void parse_arg(
             if ((DisplayModeMAX - 1) < ctl->display_mode)
                 error(EXIT_FAILURE, 0, "value out of range (%d - %d): %s",
                       DisplayModeDefault, (DisplayModeMAX - 1), optarg);
+            break;
+        case OPT_SCALE:
+            parse_scale(ctl, optarg);
             break;
         case 'c':
             ctl->MaxPing =

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -62,6 +62,11 @@ typedef int time_t;
 #define MAXFLD 20               /* max stats fields to display */
 #define FLD_INDEX_SZ 256
 
+enum {
+    MTR_SCALE_FACTORS = 10,
+    MTR_SCALE_THRESHOLDS = MTR_SCALE_FACTORS - 1
+};
+
 /* net related definitions */
 #define SAVED_PINGS 400
 #define MAX_PATH 128
@@ -110,6 +115,7 @@ struct mtr_ctl {
     int probe_timeout;          /* timeout for probe sockets */
     unsigned char fld_active[2 * MAXFLD];       /* SO_MARK to set for ping packet */
     int display_mode;           /* display mode selector */
+    int scale[MTR_SCALE_THRESHOLDS];    /* fixed stripchart scale thresholds */
     int fld_index[FLD_INDEX_SZ];        /* default display field (defined by key in net.h) and order */
     char available_options[MAXFLD];
     int display_offset;         /* only used in text mode */
@@ -118,7 +124,13 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
+        enablempls:1,
+        dns:1,
+        reportwide:1,
+        Interactive:1,
+        DisplayMode:5,
+        CompactLayout:1,
+        fixed_scale:1;
 #ifdef HAVE_IPINFO
 #ifdef ENABLE_IPV6
     char *ipinfo_provider6;


### PR DESCRIPTION
## Summary

This is a modern replacement for the old fixed-scale experiment in #227, following the shape discussed there.

The default stripchart behavior remains dynamic.  A fixed scale is only used when requested with:

- `--scale fast`
- `--scale average`
- `--scale slow`
- `--scale 5:15:25:35:45:55:101:200:400` style custom thresholds

The `average` preset uses the threshold sequence Roger suggested in #227.  Custom scales require nine strictly increasing millisecond thresholds, matching the stripchart symbols before the final overflow marker.

Supersedes #227.

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`
- `./mtr --help`
- `./mtr --report --scale average -c 1 127.0.0.1`
- `./mtr --report --scale 5:15:25:35:45:55:101:200:400 -c 1 127.0.0.1`
- `./mtr --report --scale 5:4:25:35:45:55:101:200:400 -c 1 127.0.0.1` rejects the non-increasing scale
- `timeout 3s script -q -c 'TERM=xterm ./mtr --displaymode 1 --scale average 127.0.0.1' /tmp/mtr-scale.typescript` showed `Scale: .:5 ms ... c:400 ms >`
