### PR TITLE
fix(dns): harden resolver lifecycle and results

### DIFF
--- a/ui/dns.c
+++ b/ui/dns.c
@@ -114,6 +114,13 @@ static void set_sockaddr_ip(
     memcpy(sockaddr_addr_offset(sa), ip, sockaddr_addr_size(sa));
 }
 
+static int is_useful_hostname(
+    const char *hostname)
+{
+    return hostname[0] != '\0'
+        && !(hostname[0] == '.' && hostname[1] == '\0');
+}
+
 void dns_open(
     void)
 {
@@ -176,7 +183,7 @@ void dns_open(
 
                 rv = getnameinfo((struct sockaddr *) &sa, salen,
                                  hostname, sizeof(hostname), NULL, 0, 0);
-                if (rv == 0) {
+                if (rv == 0 && is_useful_hostname(hostname)) {
                     snprintf(result, sizeof(result),
                              "%s %s\n", strlongip(family, &host), hostname);
 

--- a/ui/dns.c
+++ b/ui/dns.c
@@ -162,6 +162,9 @@ void dns_open(
             close(i);
         }
         infp = fdopen(todns[0], "r");
+        if (!infp) {
+            error(EXIT_FAILURE, errno, "fdopen DNS lookup pipe");
+        }
 
         while (fgets(buf, sizeof(buf), infp)) {
             ip_t host;
@@ -207,9 +210,17 @@ void dns_open(
         close(todns[0]);        /* close the pipe ends we don't need. */
         close(fromdns[1]);
         fromdnsfp = fdopen(fromdns[0], "r");
+        if (fromdnsfp == NULL) {
+            error(EXIT_FAILURE, errno, "fdopen DNS result pipe");
+        }
         flags = fcntl(fromdns[0], F_GETFL, 0);
+        if (flags < 0) {
+            error(EXIT_FAILURE, errno, "fcntl DNS result pipe");
+        }
         flags |= O_NONBLOCK;
-        fcntl(fromdns[0], F_SETFL, flags);
+        if (fcntl(fromdns[0], F_SETFL, flags) < 0) {
+            error(EXIT_FAILURE, errno, "fcntl DNS result pipe");
+        }
     }
 }
 

--- a/ui/dns.c
+++ b/ui/dns.c
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <sys/wait.h>
 
 #include "mtr.h"
 #include "dns.h"
@@ -71,8 +72,10 @@ char *strlongip(
 #define UNUSED_IF_NO_IPV6 ATTRIBUTE_UNUSED
 #endif
 
-static int todns[2], fromdns[2];
+static int todns[2] = { -1, -1 };
+static int fromdns[2] = { -1, -1 };
 static FILE *fromdnsfp;
+static pid_t dns_pid;
 
 static int longipstr(
     char *s,
@@ -133,6 +136,10 @@ void dns_open(
         int i;
         FILE *infp;
 
+        if (setpgid(0, 0) < 0) {
+            error(EXIT_FAILURE, errno, "can't create DNS process group");
+        }
+
         /* Automatically reap children. */
         if (signal(SIGCHLD, SIG_IGN) == SIG_ERR) {
             error(EXIT_FAILURE, errno, "signal");
@@ -186,6 +193,10 @@ void dns_open(
         int flags;
 
         /* the parent. */
+        if (setpgid(pid, pid) < 0 && errno != EACCES) {
+            error(0, errno, "can't set DNS process group");
+        }
+        dns_pid = pid;
         close(todns[0]);        /* close the pipe ends we don't need. */
         close(fromdns[1]);
         fromdnsfp = fdopen(fromdns[0], "r");
@@ -193,6 +204,44 @@ void dns_open(
         flags |= O_NONBLOCK;
         fcntl(fromdns[0], F_SETFL, flags);
     }
+}
+
+void dns_close(
+    void)
+{
+    int status;
+
+    if (todns[1] >= 0) {
+        close(todns[1]);
+        todns[1] = -1;
+    }
+    if (fromdnsfp) {
+        fclose(fromdnsfp);
+        fromdnsfp = NULL;
+        fromdns[0] = -1;
+    } else if (fromdns[0] >= 0) {
+        close(fromdns[0]);
+        fromdns[0] = -1;
+    }
+
+    if (dns_pid <= 0) {
+        return;
+    }
+
+    if (kill(-dns_pid, SIGTERM) < 0 && errno != ESRCH) {
+        error(0, errno, "kill DNS process group");
+    }
+
+    while (waitpid(dns_pid, &status, 0) < 0) {
+        if (errno != EINTR) {
+            if (errno != ECHILD) {
+                error(0, errno, "wait DNS process");
+            }
+            break;
+        }
+    }
+
+    dns_pid = 0;
 }
 
 int dns_waitfd(

--- a/ui/dns.h
+++ b/ui/dns.h
@@ -24,6 +24,8 @@
 
 extern void dns_open(
     void);
+extern void dns_close(
+    void);
 extern int dns_waitfd(
     void);
 extern void dns_ack(

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -866,6 +866,7 @@ int main(
 
         net_end_transit();
         display_close(&ctl);
+        dns_close();
         unlock(stdout);
 
         if (ctl.Interactive)

--- a/ui/report.c
+++ b/ui/report.c
@@ -46,6 +46,14 @@
 #define MAX_FORMAT_STR 320
 
 
+static int is_useful_hostname(
+    const char *hostname)
+{
+    return hostname && hostname[0] != '\0'
+        && !(hostname[0] == '.' && hostname[1] == '\0');
+}
+
+
 void report_open(
     void)
 {
@@ -64,7 +72,7 @@ static size_t snprint_addr(
     if (addrcmp((void *) addr, (void *) &ctl->unspec_addr, ctl->af)) {
         struct hostent *host =
             ctl->dns ? addr2host((void *) addr, ctl->af) : NULL;
-        if (!host)
+        if (!host || !is_useful_hostname(host->h_name))
             return snprintf(dst, dst_len, "%s", strlongip(ctl->af, addr));
         else if (ctl->dns && ctl->show_ips)
             return snprintf(dst, dst_len, "%s (%s)", host->h_name,


### PR DESCRIPTION
Fixes #220.
Fixes #448.
Fixes #449.
Supersedes #608.
Supersedes #609.

## Summary
- terminate DNS resolver subprocesses on exit instead of leaving slow lookups behind
- ignore empty and single-dot PTR hostnames so output falls back to numeric addresses
- fail explicitly if DNS resolver pipe setup fails (`fdopen()`/`fcntl()`)

## Validation
- `make -j$(nproc)`
- `git diff --check`
- `./mtr -r -c 1 127.0.0.1`
- earlier focused validation for the original pieces covered curses quit/no-leftover-process checks and the local empty-PTR resolver case.