### PR TITLE
fix(packet): retain bind-to-device capability

### DIFF
--- a/packet/construct_unix.c
+++ b/packet/construct_unix.c
@@ -882,9 +882,7 @@ int construct_ip6_packet(
 
 #ifdef SO_BINDTODEVICE
     if (param->local_device) {
-        if (setsockopt(send_socket,
-                       SOL_SOCKET, SO_BINDTODEVICE, param->local_device,
-                       strlen(param->local_device))) {
+        if (set_bind_to_device(send_socket, param->local_device)) {
             return -1;
         }
     }

--- a/packet/packet.c
+++ b/packet/packet.c
@@ -28,6 +28,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>


### PR DESCRIPTION
## Summary

Fixes #550.

`mtr-packet` keeps only selected capabilities after opening its privileged sockets.  The code intended to keep `CAP_NET_RAW` for `SO_BINDTODEVICE`, but `packet.c` checked `SO_BINDTODEVICE` without including `<sys/socket.h>`, so that block could be skipped and the permitted capability was dropped.

That made repeated `--interface` probes fail with `EPERM` once binding to the device required the capability again.  IPv6 also bypassed the helper that temporarily raises the retained capability before calling `SO_BINDTODEVICE`.

This change:

- includes `<sys/socket.h>` in `packet.c` before checking `SO_BINDTODEVICE`
- uses the existing `set_bind_to_device()` helper for IPv6 too

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `sudo python3 ./test/cmdparse.py`
- `sudo setcap cap_net_raw+ep ./mtr-packet`
- `MTR_PACKET=./mtr-packet ./mtr -6 --interface lo -r -c 1 ::1`
- `MTR_PACKET=./mtr-packet ./mtr -4 --interface lo -r -c 1 127.0.0.1`
- `sudo setcap -r ./mtr-packet`

Note: the validation forces `MTR_PACKET=./mtr-packet` so the just-built helper is tested instead of an installed system `mtr-packet` found through `PATH`.
