### PR TITLE
docs: clarify how mtr probes hops

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ mtr combines the functionality of the 'traceroute' and 'ping' programs
 in a single network diagnostic tool.
 
 As mtr starts, it investigates the network connection between the host
-mtr runs on and a user-specified destination host.  After it
-determines the address of each network hop between the machines,
-it sends a sequence of ICMP ECHO requests to each one to determine the
-quality of the link to each machine.  As it does this, it prints
-running statistics about each machine.
+mtr runs on and a user-specified destination host.  It sends probes to
+the destination with successively larger time-to-live values, and uses
+the responses from intervening routers to discover and measure the path.
+As it does this, it prints running statistics for each hop.
+
+Intermediate routers may be configured to never send these ICMP
+responses, or may rate-limit them, so apparent loss at an intermediate
+hop does not always mean that forwarded traffic is being lost at that
+point.
 
 mtr is distributed under the GNU General Public License version 2.
 See the COPYING file for details.


### PR DESCRIPTION
## Summary

Fixes #239.

The README description said that after mtr determines each network hop, it sends ICMP ECHO requests to each one.  That can mislead readers into treating apparent loss at an intermediate hop as direct evidence of forwarded packet loss there.

This rewords the description to say that mtr sends probes to the destination with increasing TTL values, uses responses from intervening routers to discover and measure the path, and notes that intermediate routers may be configured not to send those ICMP responses or may rate-limit them.

## Validation

- `git diff --check origin/master...HEAD`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson`
- `make -j "$(nproc)"`