### PR TITLE
refactor(csv): remove unused close loop

### DIFF
--- a/ui/report.c
+++ b/ui/report.c
@@ -474,12 +474,6 @@ void csv_close(
     ip_t *addr2 = NULL;
     char name[MAX_FORMAT_STR];
 
-    for (i = 0; i < MAXFLD; i++) {
-        j = ctl->fld_index[ctl->fld_active[i]];
-        if (j < 0)
-            continue;
-    }
-
     max = net_max(ctl);
     at = net_min(ctl);
     for (; at < max; at++) {


### PR DESCRIPTION
## Summary

Fixes #455.

`csv_close()` had a leading loop over the active fields that only assigned `j` and continued on invalid fields.  It did not produce output, validate state, or affect later control flow.  The real header and row generation loops immediately below still perform the same field filtering.

This removes the no-op loop.

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `./mtr -C -c 1 127.0.0.1`
