### PR TITLE
docs: align CSV separator description

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -258,17 +258,12 @@ d 7 www.isnic.is
 .TP
 .B \-C\fR, \fB\-\-csv
 Use the Comma-Separated-Value (CSV) output format.
-(Note: The separator is actually a semi-colon ';'.)
 .IP
 Example of the CSV output format:
 .nf
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;1;r-76520-PROD.greenqloud.internal;288
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;2;46.149.16.4;2086
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;3;172.31.1.16;600
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;4;82.221.168.236;1163
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;5;???;0
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;6;rix-k2-gw.isnic.is;1654
-MTR.0.86+git:16e39fc0;1435562787;OK;nic.is;7;www.isnic.is;1036
+Mtr_Version,Start_Time,Status,Host,Hop,Ip,Loss%,Snt, ,Last,Avg,Best,Wrst,StDev
+MTR.0.96,1754901135,OK,nic.is,1,192.0.2.1,0.00,1,0,1.23,1.23,1.23,1.23,0.00
+MTR.0.96,1754901135,OK,nic.is,2,198.51.100.1,0.00,1,0,3.45,3.45,3.45,3.45,0.00
 .fi
 .TP
 .B \-j\fR, \fB\-\-json


### PR DESCRIPTION
## Summary

Fixes #452.

The manual described `--csv` as CSV output, then immediately noted that the separator was actually a semicolon.  The implementation currently emits comma-separated rows, and Roger suggested that the easiest fix is to remove the stale note rather than changing the output format used by scripts.

This removes the semicolon note and updates the example to show comma-separated output. The branch composes cleanly after #575, where the CSV spacer column is removed.

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `./mtr -C -c 1 127.0.0.1`
- fresh #600 stack merge confirmed this PR applies cleanly after #575
