### PR TITLE
fix(dns): ignore empty PTR hostnames

### DIFF
--- a/ui/dns.c
+++ b/ui/dns.c
@@ -111,6 +111,13 @@ static void set_sockaddr_ip(
     memcpy(sockaddr_addr_offset(sa), ip, sockaddr_addr_size(sa));
 }
 
+static int is_useful_hostname(
+    const char *hostname)
+{
+    return hostname[0] != '\0'
+        && !(hostname[0] == '.' && hostname[1] == '\0');
+}
+
 void dns_open(
     void)
 {
@@ -169,7 +176,7 @@ void dns_open(
 
                 rv = getnameinfo((struct sockaddr *) &sa, salen,
                                  hostname, sizeof(hostname), NULL, 0, 0);
-                if (rv == 0) {
+                if (rv == 0 && is_useful_hostname(hostname)) {
                     snprintf(result, sizeof(result),
                              "%s %s\n", strlongip(family, &host), hostname);
 

--- a/ui/report.c
+++ b/ui/report.c
@@ -46,6 +46,14 @@
 #define MAX_FORMAT_STR 320
 
 
+static int is_useful_hostname(
+    const char *hostname)
+{
+    return hostname && hostname[0] != '\0'
+        && !(hostname[0] == '.' && hostname[1] == '\0');
+}
+
+
 void report_open(
     void)
 {
@@ -64,7 +72,7 @@ static size_t snprint_addr(
     if (addrcmp((void *) addr, (void *) &ctl->unspec_addr, ctl->af)) {
         struct hostent *host =
             ctl->dns ? addr2host((void *) addr, ctl->af) : NULL;
-        if (!host)
+        if (!host || !is_useful_hostname(host->h_name))
             return snprintf(dst, dst_len, "%s", strlongip(ctl->af, addr));
         else if (ctl->dns && ctl->show_ips)
             return snprintf(dst, dst_len, "%s (%s)", host->h_name,


### PR DESCRIPTION
## Summary

Fixes #449.

Some reverse DNS records can resolve to `.`.  That is not useful as a display hostname, and #449 shows it can lead to confusing output where a previous hostname appears to be reused for the hop.

This treats empty and single-dot PTR names as absent hostnames:

- async DNS lookup workers do not cache them
- report/XML/CSV formatting falls back to the numeric address when `addr2host()` returns one

## Validation

- `make -j "$(nproc)"`
- `git diff --check`
- `getent hosts 188.209.56.29` returns `188.209.56.29   .` on this system
- `timeout 20s ./mtr -r -c 1 188.209.56.29`
- `timeout 5s script -q -c 'TERM=xterm ./mtr -b 188.209.56.29' /tmp/mtr-null-ptr.typescript`

The live route from this environment did not reach the final problematic hop before timing out, but the resolver result used by the bug report is reproducible here.
