### PR TITLE
fix(dns): check resolver pipe setup failures

### DIFF
--- a/ui/dns.c
+++ b/ui/dns.c
@@ -148,6 +148,9 @@ void dns_open(
             close(i);
         }
         infp = fdopen(todns[0], "r");
+        if (infp == NULL) {
+            error(EXIT_FAILURE, errno, "fdopen DNS input pipe");
+        }
 
         while (fgets(buf, sizeof(buf), infp)) {
             ip_t host;
@@ -189,9 +192,17 @@ void dns_open(
         close(todns[0]);        /* close the pipe ends we don't need. */
         close(fromdns[1]);
         fromdnsfp = fdopen(fromdns[0], "r");
+        if (fromdnsfp == NULL) {
+            error(EXIT_FAILURE, errno, "fdopen DNS result pipe");
+        }
         flags = fcntl(fromdns[0], F_GETFL, 0);
+        if (flags < 0) {
+            error(EXIT_FAILURE, errno, "fcntl DNS result pipe");
+        }
         flags |= O_NONBLOCK;
-        fcntl(fromdns[0], F_SETFL, flags);
+        if (fcntl(fromdns[0], F_SETFL, flags) < 0) {
+            error(EXIT_FAILURE, errno, "fcntl DNS result pipe");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #448.

## Summary
- fail explicitly if DNS resolver pipe `fdopen()` setup fails in the helper or parent
- check both `fcntl()` calls before using the resolver result pipe in nonblocking mode

## Validation
- `make -j$(nproc)`
- `git diff --check`
- `./mtr --version`
- `./mtr --help`
- `./mtr -r -c 1 127.0.0.1`

## Notes
This intentionally addresses the concrete unchecked pipe setup path from #448 without adding broad output-wrapper macros around `printf()`/`putchar()`.