### PR TITLE
fix(cmdpipe): explain probe permission errors

### DIFF
--- a/ui/cmdpipe.c
+++ b/ui/cmdpipe.c
@@ -662,7 +662,8 @@ void handle_reply_errors(
 
     if (!strcmp(reply_name, "permission-denied")) {
         display_close(ctl);
-        error(EXIT_FAILURE, 0, "Permission denied");
+        error(EXIT_FAILURE, 0,
+              "mtr-packet reported permission denied while sending a probe");
     }
 
     if (!strcmp(reply_name, "address-in-use")) {


### PR DESCRIPTION
Fixes #427.

## Summary
- replace the bare `Permission denied` UI message for `mtr-packet` probe failures with a message that names the packet helper and the probe-send operation
- keep the error tied to the existing `permission-denied` reply from `mtr-packet` rather than guessing whether the cause is firewall policy, raw-socket permissions, or another OS policy

## Validation
- `make -j$(nproc)`
- `git diff --check`
- fake `MTR_PACKET` smoke returning `permission-denied` for `send-probe` now prints `mtr-packet reported permission denied while sending a probe`
- `./mtr -r -c 1 127.0.0.1`