### PR TITLE
feat(curses): add startup and exit controls

### DIFF
--- a/bash-completion/mtr
+++ b/bash-completion/mtr
@@ -55,7 +55,7 @@ _mtr_module()
         --max-ttl --max-unknown --port --localport --psize --bitpattern
         --interval --gracetime --tos --mpls --timeout --mark --report
         --report-wide --report-cycles --json --xml --csv --raw --split
-        --curses --displaymode --gtk --no-dns --show-ips --order --ipinfo
+        --curses --displaymode --compact --report-on-exit --gtk --no-dns --show-ips --order --ipinfo
         --aslookup --help --version
       '
       COMPREPLY=( $(compgen -W "${OPTS[*]}" -- "$cur") )

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -29,6 +29,12 @@ mtr \- a network diagnostic tool
 .BI \--displaymode \ MODE\c
 ]
 [\c
+.B \-\-compact\c
+]
+[\c
+.B \-\-report\-on\-exit\c
+]
+[\c
 .B \-\-raw\c
 ]
 [\c
@@ -194,6 +200,11 @@ mode.  When in this mode,
 .B mtr
 will not cut hostnames in the report.
 .TP
+.B \-\-report\-on\-exit
+Use this option with the curses interface to print a report snapshot after
+leaving curses mode. This keeps the last trace visible in terminals that switch
+to an alternate screen while curses is active.
+.TP
 .B \-x\fR, \fB\-\-xml
 Use this option to tell
 .B mtr
@@ -221,6 +232,9 @@ Use this option to select the initial display mode: 0 (default)
 selects statistics, 1 selects the stripchart without latency
 information, and 2 selects the stripchart with latency
 information.
+.TP
+.B -\-compact
+Use this option to start the curses interface in compact mode.
 .TP
 .B \-g\fR, \fB\-\-gtk
 Use this option to force

--- a/ui/display.c
+++ b/ui/display.c
@@ -146,6 +146,8 @@ void display_close(
         asn_close(ctl);
 #endif
         mtr_curses_close();
+        if (ctl->ReportOnExit)
+            report_close(ctl);
         break;
 #endif
     case DisplaySplit:

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -124,6 +124,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 #endif       
     fputs(" -r, --report                     output using report mode\n", out);
     fputs(" -w, --report-wide                output wide report\n", out);
+    fputs("     --report-on-exit             print report after curses exits\n", out);
     fputs(" -c, --report-cycles COUNT        set the number of pings sent\n", out);       
 #ifdef HAVE_JANSSON       
     fputs(" -j, --json                       output json\n", out);
@@ -136,6 +137,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs(" -t, --curses                     use curses terminal interface\n", out);       
 #endif       
     fputs("     --displaymode MODE           select initial display mode\n", out);       
+    fputs("     --compact                    start curses interface in compact mode\n", out);
 #ifdef HAVE_GTK       
     fputs(" -g, --gtk                        use GTK+ xwindow interface\n", out);
 #endif       
@@ -301,9 +303,11 @@ static void parse_arg(
      */
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
-        OPT_IPINFO4 = CHAR_MAX + 2,
+        OPT_REPORT_ON_EXIT = CHAR_MAX + 2,
+        OPT_IPINFO4 = CHAR_MAX + 3,
+        OPT_COMPACT = CHAR_MAX + 4,
 #ifdef ENABLE_IPV6
-        OPT_IPINFO6 = CHAR_MAX + 3,
+        OPT_IPINFO6 = CHAR_MAX + 5,
 #endif /* ifdef ENABLE_IPV6 */
     };
     static const struct option long_options[] = {
@@ -319,6 +323,7 @@ static void parse_arg(
 
         {"report", 0, NULL, 'r'},
         {"report-wide", 0, NULL, 'w'},
+        {"report-on-exit", 0, NULL, OPT_REPORT_ON_EXIT},
         {"xml", 0, NULL, 'x'},
 #ifdef HAVE_CURSES
         {"curses", 0, NULL, 't'},
@@ -332,6 +337,7 @@ static void parse_arg(
         {"json", 0, NULL, 'j'},
 #endif
         {"displaymode", 1, NULL, OPT_DISPLAYMODE},
+        {"compact", 0, NULL, OPT_COMPACT},
         {"split", 0, NULL, 'p'},        /* BL */
         /* maybe above should change to -d 'x' */
 
@@ -412,6 +418,9 @@ static void parse_arg(
             ctl->reportwide = 1;
             ctl->DisplayMode = DisplayReport;
             break;
+        case OPT_REPORT_ON_EXIT:
+            ctl->ReportOnExit = 1;
+            break;
 #ifdef HAVE_CURSES
         case 't':
             ctl->DisplayMode = DisplayCurses;
@@ -446,6 +455,9 @@ static void parse_arg(
             if ((DisplayModeMAX - 1) < ctl->display_mode)
                 error(EXIT_FAILURE, 0, "value out of range (%d - %d): %s",
                       DisplayModeDefault, (DisplayModeMAX - 1), optarg);
+            break;
+        case OPT_COMPACT:
+            ctl->CompactLayout = 1;
             break;
         case 'c':
             ctl->MaxPing =

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -118,7 +118,8 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
+        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5,
+        CompactLayout:1, ReportOnExit:1;
 #ifdef HAVE_IPINFO
 #ifdef ENABLE_IPV6
     char *ipinfo_provider6;


### PR DESCRIPTION
Fixes #323.
Fixes #549.
Supersedes #580.
Supersedes #584.

## Summary
- add `--compact` to start the curses UI in compact layout
- add `--report-on-exit` to print a report snapshot after leaving curses mode
- document both options and include them in bash completion

## Validation
- `make -j$(nproc)`
- `git diff --check`
- `./mtr --help | rg -- '--compact|--report-on-exit'`
- `./mtr --compact --report-on-exit -r -c 1 127.0.0.1`