### PR TITLE
refactor(dns): share hostname usefulness helper

### DIFF
--- a/ui/dns.c
+++ b/ui/dns.c
@@ -114,13 +114,6 @@ static void set_sockaddr_ip(
     memcpy(sockaddr_addr_offset(sa), ip, sockaddr_addr_size(sa));
 }
 
-static int is_useful_hostname(
-    const char *hostname)
-{
-    return hostname[0] != '\0'
-        && !(hostname[0] == '.' && hostname[1] == '\0');
-}
-
 void dns_open(
     void)
 {

--- a/ui/report.c
+++ b/ui/report.c
@@ -47,14 +47,6 @@
 #define MAX_FORMAT_STR 320
 
 
-static int is_useful_hostname(
-    const char *hostname)
-{
-    return hostname && hostname[0] != '\0'
-        && !(hostname[0] == '.' && hostname[1] == '\0');
-}
-
-
 void report_open(
     void)
 {

--- a/ui/utils.h
+++ b/ui/utils.h
@@ -40,6 +40,13 @@ static inline void xstrncpy(
     dest[n - 1] = 0;
 }
 
+static inline int is_useful_hostname(
+    const char *hostname)
+{
+    return hostname && hostname[0] != '\0'
+        && !(hostname[0] == '.' && hostname[1] == '\0');
+}
+
 extern void *xmalloc(
     const size_t size);
 extern char *xstrdup(


### PR DESCRIPTION
## Summary

Follow-up to #603 per reviewer request.

Both `ui/dns.c` and `ui/report.c` had local copies of `is_useful_hostname`. Move the helper to `ui/utils.h` as a `static inline` helper so both call sites share the same empty-hostname and single-dot filtering.

The shared helper keeps the null-safe behavior that `ui/report.c` already had; `ui/dns.c` only passes a stack buffer after successful `getnameinfo`, so this does not change its normal path.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`