### PR TITLE
docs: document braille display mode

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -228,7 +228,8 @@ clears spurious error messages that may overwrite other parts of the display.
 Use this option to select the initial display mode: 0 (default)
 selects statistics, 1 selects the stripchart without latency
 information, and 2 selects the stripchart with latency
-information.
+information.  If braille graphs were enabled at build time and wide
+curses support is available, 3 selects a braille stripchart.
 In stripchart modes,
 .B ?
 marks a probe that has not received a response, and


### PR DESCRIPTION
## Summary

Follow-up from reviewing the old `yvs2014/mtr085` graph work and issue #96.

The current curses frontend already has a braille stripchart mode behind `WITH_BRAILLE_DISPLAY`, but the man page only documented display modes 0, 1, and 2.  Document display mode 3 and the build-time requirement for wide curses plus braille support.

## Provenance

- Triggered by issue #96 and the `yvs2014/mtr085` graph/histogram review.
- The current upstream braille mode itself came from Bart Trojanowski
`<bart@jukie.net>` via commit `25fc5274ef49465cf0c3236ebf2445ddf49f4647` / PR #530.
- This PR only documents that already-merged mode.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`