### PR TITLE
net: resolve IDN hostnames with AI_IDN

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,13 @@ AC_CHECK_DECLS([errno], [], [], [[
 #include <errno.h>
 #include <sys/errno.h>
   ]])
+AC_CHECK_DECLS([AI_IDN], [], [], [[
+#include <sys/types.h>
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+#include <netdb.h>
+  ]])
 
 AC_CHECK_TYPE([socklen_t],
   [AC_DEFINE([HAVE_SOCKLEN_T], [], [Define if your system has socklen_t])], [],

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -787,6 +787,9 @@ int get_addrinfo_from_name(
     memset(&hints, 0, sizeof hints);
     hints.ai_family = ctl->af;
     hints.ai_socktype = SOCK_DGRAM;
+#if HAVE_DECL_AI_IDN
+    hints.ai_flags = AI_IDN;
+#endif
     gai_error = getaddrinfo(name, NULL, &hints, res);
     if (gai_error) {
         if (gai_error == EAI_SYSTEM)
@@ -831,6 +834,9 @@ static int validate_report_targets(
         memset(&hints, 0, sizeof hints);
         hints.ai_family = lookup_ctl.af;
         hints.ai_socktype = SOCK_DGRAM;
+#if HAVE_DECL_AI_IDN
+        hints.ai_flags = AI_IDN;
+#endif
         gai_error = getaddrinfo(names->name, NULL, &hints, &res);
         if (gai_error) {
             if (gai_error == EAI_SYSTEM) {


### PR DESCRIPTION
## Summary

Cherry-picked a small, dependency-free part of the IDN support from `yvs2014/mtr085`.

When libc exposes `AI_IDN`, pass it to `getaddrinfo()` for target resolution and multi-target report preflight.  This lets libc convert internationalized hostnames such as `köthe.de` to their DNS form without adding libidn/libidn2 as a new dependency.

Platforms without `AI_IDN` keep the existing behavior because configure records `HAVE_DECL_AI_IDN=0`.

## Provenance

- Ported from `yvs2014/mtr085` commit `f897e61ad950499acdf213207fe08b5dce75293e` (`rm libidn dependenccy if IDN is supported by getaddrinfo`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- This PR ports only the libc `AI_IDN` part, not the libidn/libidn2 fallback.

## Validation

- `./bootstrap.sh && ./configure --without-gtk --without-jansson`
- `git diff --check`
- `make -j "$(nproc)"`
- `timeout 35s env MTR_PACKET=./mtr-packet ./mtr -r -c 1 köthe.de`