### PR TITLE
csv: preserve blank output fields

### DIFF
--- a/ui/report.c
+++ b/ui/report.c
@@ -579,6 +579,10 @@ void csv_close(
                 j = ctl->fld_index[ctl->fld_active[i]];
                 if (j < 0)
                     continue;
+                if (data_fields[j].key == ' ') {
+                    printf(",");
+                    continue;
+                }
                 printf("%s,", data_fields[j].title);
             }
             printf("\n");
@@ -599,6 +603,10 @@ void csv_close(
             j = ctl->fld_index[ctl->fld_active[i]];
             if (j < 0)
                 continue;
+            if (data_fields[j].key == ' ') {
+                printf(",");
+                continue;
+            }
 
             /* 1000.0 is a temporary hack for stats usec to ms, impacted net_loss. */
             if (strchr(data_fields[j].format, 'f')) {
@@ -652,6 +660,10 @@ void csv_close(
                         j = ctl->fld_index[ctl->fld_active[i]];
                         if (j < 0)
                             continue;
+                        if (data_fields[j].key == ' ') {
+                            printf(",");
+                            continue;
+                        }
 
                         /* 1000.0 is a temporary hack for stats usec to ms, impacted net_loss. */
                         if (strchr(data_fields[j].format, 'f')) {


### PR DESCRIPTION
## Summary

Port the CSV blank-field behavior from `yvs2014/mtr085`.

The output field order can contain spaces as visual separators.  In CSV mode those separators should become empty CSV columns, not data columns populated through the `net_drop` callback.

With this change, `-C -o 'L S'` emits `Loss%,,Snt,` and `0.00,,1` instead of putting `0` in the separator column.

## Provenance

- Ported from `yvs2014/mtr085` commit `1871c38c4735112adcecc7cef31091e6d0e7f261` (`csv: do not skip blank fields`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- Commit author is preserved as yvs; this PR ports only the current-upstream `ui/report.c` behavior, not the unrelated packaging changes from the source commit.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`
- `timeout 20s env MTR_PACKET=./mtr-packet ./mtr -C -c 1 -o 'L S' 127.0.0.1`