### PR TITLE
options: reject invalid bit patterns

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -400,9 +400,8 @@ If set to a negative number, every iteration will use a different, random
 packet size up to that number.
 .TP
 .B \-B \fINUM\fR, \fB\-\-bitpattern \fINUM
-Specifies bit pattern to use in payload.  Should be within range 0 - 255.  If
-.I NUM
-is greater than 255, a random pattern is used.
+Specifies bit pattern to use in payload.  Should be within range 0 - 255,
+or -1 to use a random pattern.
 .TP
 .B \-G \fISECONDS\fR, \fB\-\-gracetime \fISECONDS
 Use this option to specify the positive number of seconds to wait for responses

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -409,7 +409,7 @@ static void parse_arg(
         {"interval", 1, NULL, 'i'},
         {"report-cycles", 1, NULL, 'c'},
         {"psize", 1, NULL, 's'},        /* overload psize<0, ->rand(min,max) */
-        {"bitpattern", 1, NULL, 'B'},   /* overload B>255, ->rand(0,255) */
+        {"bitpattern", 1, NULL, 'B'},   /* -1 random, otherwise 0..255 */
         {"tos", 1, NULL, 'Q'},  /* typeof service (0,255) */
         {"mpls", 0, NULL, 'e'},
         {"interface", 1, NULL, 'I'},
@@ -599,8 +599,10 @@ static void parse_arg(
         case 'B':
             ctl->bitpattern =
                 strtoint_or_err(optarg, "invalid argument");
-            if (ctl->bitpattern > 255)
-                ctl->bitpattern = -1;
+            if (ctl->bitpattern < -1 || ctl->bitpattern > 255) {
+                error(EXIT_FAILURE, 0, "value out of range (-1 - 255): %s",
+                      optarg);
+            }
             break;
         case 'G':
             ctl->GraceTime = strtofloat_or_err(optarg, "invalid argument");


### PR DESCRIPTION
## Summary

Port the bitpattern validation piece from `yvs2014/mtr085`.

`--bitpattern` now accepts either a payload byte value in `0..255` or `-1` for random mode. Other negative values and values above 255 are rejected instead of silently selecting random mode. The curses `b` command now uses the same range.

## Provenance

- Ported from `yvs2014/mtr085` commit `e100fd72be37f0a98d6893db7e0baa8a5b81b72a` (`use arc4random if it's available, and put extra checks for -B/-s options`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- Commit author is preserved as yvs; this PR ports only the bitpattern validation/docs part because current upstream already validates packet size.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`
- `./mtr -B-2 -r -c 1 127.0.0.1` rejects the invalid negative bitpattern
- `./mtr -B 256 -r -c 1 127.0.0.1` rejects values above 255
- `timeout 20s env MTR_PACKET=./mtr-packet ./mtr -B-1 -r -c 1 127.0.0.1`
