### PR TITLE
curses: keep bit pattern range consistent

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -25,6 +25,7 @@
 #include <windows.h>
 #endif
 #include <assert.h>
+#include <errno.h>
 #include <strings.h>
 #include <unistd.h>
 
@@ -223,7 +224,7 @@ int mtr_curses_keyaction(
         return ActionNone;
     case 'b':
         mvprintw(2, 0, "Ping Bit Pattern: %d\n", ctl->bitpattern);
-        mvprintw(3, 0, "Pattern Range: 0(0x00)-255(0xff), <0 random.\n");
+        mvprintw(3, 0, "Pattern Range: 0(0x00)-255(0xff), -1 random.\n");
         move(2, 18);
         refresh();
         while ((c = getch()) != '\n' && i < MAXFLD) {
@@ -234,9 +235,15 @@ int mtr_curses_keyaction(
             buf[i++] = c;       /* need more checking on 'c' */
         }
         buf[i] = '\0';
-        ctl->bitpattern = atoi(buf);
-        if (ctl->bitpattern > 255)
-            ctl->bitpattern = -1;
+        char *end = NULL;
+        errno = 0;
+        long new_bitpattern = strtol(buf, &end, 10);
+        if (errno != 0 || buf == end || *end != '\0' ||
+            new_bitpattern < -1 || new_bitpattern > 255) {
+            printf("\a");
+            return ActionNone;
+        }
+        ctl->bitpattern = new_bitpattern;
         return ActionNone;
     case 'i':
         mvprintw(2, 0, "Interval : %0.0f\n\n", ctl->WaitTime);
@@ -381,7 +388,7 @@ int mtr_curses_keyaction(
             ("  m <n>   set the max time-to-live, default n= # of hops\n");
         printw("  s <n>   set the packet size to n or random(n<0)\n");
         printw
-            ("  b <c>   set ping bit pattern to c(0..255) or random(c<0)\n");
+            ("  b <c>   set ping bit pattern to c(0..255) or random(c=-1)\n");
         printw("  Q <t>   set ping packet's TOS to t\n");
         printw("  u       switch between ICMP ECHO and UDP datagrams\n");
         printw("  t       switch between ICMP ECHO and TCP\n");


### PR DESCRIPTION
## Summary

Follow up to #625 for the interactive curses command path.

The curses `b` command now matches `--bitpattern`: it accepts `0..255` or `-1` for random mode, rejects other negative values instead of treating them as random mode, and rejects non-numeric input instead of letting `atoi()` silently turn it into `0`.

## Provenance

- Ported from `yvs2014/mtr085` commit `e100fd72be37f0a98d6893db7e0baa8a5b81b72a` (`use arc4random if it's available, and put extra checks for -B/-s options`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- Commit author is preserved as yvs; this PR ports only the curses bitpattern range piece because #625 already merged the command-line path.

## Validation

- `git diff --check`
- `make -j$(nproc)`
