### PR TITLE
net: use arc4random_uniform when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ AC_CHECK_SIZEOF([unsigned long], [4])
 # Check headers.
 AC_CHECK_HEADERS([ \
   arpa/nameser_compat.h \
+  bsd/stdlib.h \
   curses.h \
   cursesX.h \
   error.h \
@@ -67,6 +68,9 @@ AC_CHECK_FUNCS([ \
   __fpending \
   fcntl \
 ])
+AC_SEARCH_LIBS([arc4random_uniform], [bsd],
+  [AC_DEFINE([HAVE_ARC4RANDOM_UNIFORM], [1],
+    [Define to 1 if arc4random_uniform is available.])])
 
 AC_CHECK_FUNC([error], [with_error=no],
   [AC_CHECK_FUNCS([verr verrx vwarn vwarnx], [with_error=yes],

--- a/ui/net.c
+++ b/ui/net.c
@@ -27,6 +27,10 @@
 #include <sys/select.h>
 #include <unistd.h>
 
+#if defined(HAVE_ARC4RANDOM_UNIFORM) && defined(HAVE_BSD_STDLIB_H)
+#include <bsd/stdlib.h>
+#endif
+
 #ifdef HAVE_ERROR_H
 #include <error.h>
 #else
@@ -45,6 +49,16 @@
 #define MaxSequence 65536
 
 static int packetsize;          /* packet size used by ping */
+
+static int random_uniform(
+    int upper_bound)
+{
+#ifdef HAVE_ARC4RANDOM_UNIFORM
+    return (int) arc4random_uniform((unsigned int) upper_bound);
+#else
+    return rand() % upper_bound;
+#endif
+}
 
 struct nethost {
     ip_t addr;                  /* Latest host to respond */
@@ -577,14 +591,14 @@ int net_send_batch(
                 packetsize = MINPACKET;
             } else {
                 packetsize =
-                    MINPACKET + rand() % (-ctl->cpacketsize - MINPACKET);
+                    MINPACKET + random_uniform(-ctl->cpacketsize - MINPACKET);
             }
         } else {
             packetsize = ctl->cpacketsize;
         }
         if (ctl->bitpattern < 0) {
             ctl->bitpattern =
-                -(int) (256 + 255 * (rand() / (RAND_MAX + 0.1)));
+                -(256 + random_uniform(256));
         }
     }
 


### PR DESCRIPTION
## Summary

Port the `arc4random_uniform` randomization piece from `yvs2014/mtr085`.

When the platform provides `arc4random_uniform`, random packet sizes and random payload bit patterns use it instead of `rand()`. Platforms without it keep the existing `rand()` fallback.

## Provenance

- Ported from `yvs2014/mtr085` commit `e100fd72be37f0a98d6893db7e0baa8a5b81b72a` (`use arc4random if it's available, and put extra checks for -B/-s options`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- Commit author is preserved as yvs; this PR ports only the `arc4random_uniform` randomization piece because the bitpattern validation was split into #625 and #626.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`
- `./configure --without-gtk --without-jansson` detects `arc4random_uniform` on this host and builds
- `./configure --without-gtk --without-jansson ac_cv_search_arc4random_uniform=no && make -j "$(nproc)"` verifies the fallback build
- `./mtr -B-1 -r -c 1 127.0.0.1`
- `./mtr -s -64 -r -c 1 127.0.0.1`
