### PR TITLE
curses: validate packet size input

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -217,8 +217,11 @@ int mtr_curses_keyaction(
         }
         buf[i] = '\0';
         int new_packetsize = atoi(buf);
-        if (abs(ctl->cpacketsize) >= MINPACKET && abs(ctl->cpacketsize) < MAXPACKET) {
+        if (abs(new_packetsize) >= MINPACKET
+            && abs(new_packetsize) <= MAXPACKET) {
             ctl->cpacketsize = new_packetsize;
+        } else {
+            printf("\a");
         }
         return ActionNone;
     case 'b':


### PR DESCRIPTION
## Summary

Port the interactive packet-size validation piece from `yvs2014/mtr085`.

The curses `s` command now validates the newly entered packet size before assigning it. This keeps the interactive path aligned with command-line `--psize`, including negative random packet-size values.

## Provenance

- Ported from `yvs2014/mtr085` commit `e100fd72be37f0a98d6893db7e0baa8a5b81b72a` (`use arc4random if it's available, and put extra checks for -B/-s options`).
- Original author: yvs `<VSYakovetsky@gmail.com>`.
- Commit author is preserved as yvs; this PR ports only the curses packet-size validation piece.

## Validation

- `git diff --check`
- `make -j "$(nproc)"`
