### PR TITLE
net: simplify AI_IDN guards

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_CHECK_HEADERS([ \
   linux/errqueue.h \
   ncurses.h \
   ncurses/curses.h \
+  netdb.h \
   netinet/in.h \
   socket.h \
   sys/cdefs.h \
@@ -207,14 +208,6 @@ AC_CHECK_DECLS([errno], [], [], [[
 #include <errno.h>
 #include <sys/errno.h>
   ]])
-AC_CHECK_DECLS([AI_IDN], [], [], [[
-#include <sys/types.h>
-#ifdef HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif
-#include <netdb.h>
-  ]])
-
 AC_CHECK_TYPE([socklen_t],
   [AC_DEFINE([HAVE_SOCKLEN_T], [], [Define if your system has socklen_t])], [],
   [[#include <netinet/in.h>

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -39,7 +39,9 @@
 #ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
 #endif
+#ifdef HAVE_NETDB_H
 #include <netdb.h>
+#endif
 #include <netinet/in.h>
 #include <resolv.h>
 #include <string.h>

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -851,7 +851,7 @@ int get_addrinfo_from_name(
     memset(&hints, 0, sizeof hints);
     hints.ai_family = ctl->af;
     hints.ai_socktype = SOCK_DGRAM;
-#if HAVE_DECL_AI_IDN
+#ifdef AI_IDN
     hints.ai_flags = AI_IDN;
 #endif
     gai_error = getaddrinfo(name, NULL, &hints, res);
@@ -898,7 +898,7 @@ static int validate_report_targets(
         memset(&hints, 0, sizeof hints);
         hints.ai_family = lookup_ctl.af;
         hints.ai_socktype = SOCK_DGRAM;
-#if HAVE_DECL_AI_IDN
+#ifdef AI_IDN
         hints.ai_flags = AI_IDN;
 #endif
         gai_error = getaddrinfo(names->name, NULL, &hints, &res);

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -23,7 +23,9 @@
 #include "config.h"
 
 #include <stdint.h>
+#ifdef HAVE_NETDB_H
 #include <netdb.h>
+#endif
 #include <sys/socket.h>
 #include <arpa/inet.h>
 

--- a/ui/net.h
+++ b/ui/net.h
@@ -18,7 +18,9 @@
 
 /*  Prototypes for functions in net.c  */
 #include <sys/types.h>
+#ifdef HAVE_NETDB_H
 #include <netdb.h>
+#endif
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/ui/report.c
+++ b/ui/report.c
@@ -20,7 +20,9 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#ifdef HAVE_NETDB_H
 #include <netdb.h>
+#endif
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <string.h>


### PR DESCRIPTION
## Summary

Follow up on yvs2014's review note in #620.

This switches the IDN resolver guard from the generated `HAVE_DECL_AI_IDN` check to a direct `#ifdef AI_IDN`, and adds `netdb.h` to the configure header checks so the relevant header availability is explicit. Existing `netdb.h` includes are now guarded with `HAVE_NETDB_H`.

This keeps the scope to the libc `AI_IDN` path from #620; it does not add a libidn/libidn2 fallback.

## Provenance

- Suggested by yvs2014 in https://github.com/traviscross/mtr/pull/620#issuecomment-4406661314

## Validation

- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- `timeout 35s env MTR_PACKET=./mtr-packet ./mtr -r -c 1 köthe.de`
