### PR TITLE
curses: drain queued resize events

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -147,6 +147,25 @@ int mtr_curses_keyaction(
     float f = 0.0;
     char buf[MAXFLD + 1];
 
+#ifdef KEY_RESIZE
+    /*
+       Some curses implementations may queue many resize events while the
+       terminal is being dragged.  Drain a bounded batch so real key input
+       can be handled again after the resize settles.
+     */
+    if (c == KEY_RESIZE) {
+        int resize_events;
+
+        for (resize_events = 0; resize_events < 100 && c == KEY_RESIZE;
+             resize_events++) {
+            c = getch();
+        }
+        if (c == KEY_RESIZE) {
+            flushinp();
+        }
+    }
+#endif
+
     if (c == 'Q') {             /* must be checked before c = tolower(c) */
         mvprintw(2, 0, "Type of Service(tos): %d\n", ctl->tos);
         mvprintw(3, 0,


### PR DESCRIPTION
## Summary
- drain a bounded run of queued `KEY_RESIZE` events before handling curses key input
- flush the input queue only if resize events are still arriving after the bounded drain

## Why
This ports a small interactive curses fix from the mtr085 fork. Some curses implementations can queue repeated resize notifications while the terminal is being dragged; if mtr keeps reading those as ordinary input events, real key input may appear frozen until the queue clears.

## Provenance
- Ported from `yvs2014/mtr085@249b8e97db05f4deb80c8df44cebb71f6424ec54`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records the source SHA.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- GitHub `compile-linux` and `lint` passed
- Included in the newest-to-oldest stack validation in #646

## Notes
This is an interactive terminal-resize behavior change, so terminal-specific confirmation is still useful during review.
