### PR TITLE
split: support more interactive keys

### DIFF
--- a/ui/split.c
+++ b/ui/split.c
@@ -200,6 +200,22 @@ int split_keyaction(
         return ActionQuit;
     if (tolower(c) == 'r')
         return ActionReset;
+    if (tolower(c) == 'p')
+        return ActionPause;
+    if (c == ' ')
+        return ActionResume;
+    if (tolower(c) == 'd')
+        return ActionDisplay;
+    if (tolower(c) == 'c')
+        return ActionCompact;
+    if (tolower(c) == 'e')
+        return ActionMPLS;
+    if (tolower(c) == 'n')
+        return ActionDNS;
+    if (c == '+')
+        return ActionScrollDown;
+    if (c == '-')
+        return ActionScrollUp;
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- teach split mode to return more of the interactive actions already supported by the main select loop
- add keys for pause/resume, display cycling, compact mode, MPLS, DNS, and scroll offset changes

## Why
This ports a small split-mode usability improvement from the mtr085 fork without bringing over the larger fork-specific command/help system. Upstream split mode already runs through the same `display_keyaction()`/select-loop action path as curses mode, but it currently only handles quit and reset.

## Provenance
- Adapted from `yvs2014/mtr085@097bda215b79cac11b54a8a7baead218c1868b6c`
- Also incorporates the later key-message refinement context from `yvs2014/mtr085@c69b13656f921c00c85581cac23f5f2b438ca186`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records both source SHAs.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- GitHub `compile-linux` and `lint` passed
- Included in the newest-to-oldest stack validation in #646

## Notes
This is an interactive split-mode behavior change, so terminal-specific confirmation is still useful during review.
