### PR TITLE
options: reject invalid tos values

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -627,9 +627,8 @@ static void parse_arg(
             ctl->tos =
                 strtoint_or_err(optarg, "invalid argument");
             if (ctl->tos > 255 || ctl->tos < 0) {
-                /* error message, should do more checking for valid values,
-                 * details in rfc2474 */
-                ctl->tos = 0;
+                error(EXIT_FAILURE, 0, "value out of range (0 - 255): %s",
+                      optarg);
             }
             break;
         case 'u':


### PR DESCRIPTION
## Summary
- reject `-Q/--tos` values outside the valid `0..255` range
- stop silently resetting invalid ToS input to `0`

## Why
The ToS value is an 8-bit IP header field. If a user passes a typo such as `--tos 999`, silently probing with ToS `0` hides the mistake and makes the command look successful with different settings than requested.

## Provenance
- Ported from the range-validation part of `yvs2014/mtr085@f02159767600cf934e9ed51bc7050be806d9d185`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records the source SHA.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- `./mtr --tos 999 --report --report-cycles 1 127.0.0.1` exits with `value out of range (0 - 255): 999`
- `./mtr --tos 255 --help` exits successfully
