### PR TITLE
net: unmap IPv4-mapped targets by default

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -833,6 +833,44 @@ static void init_rand(
     srand(((getpid() & 0xffff) << 16) ^ getuid() ^ tv.tv_sec ^ tv.tv_usec);
 }
 
+static void unmap_v4mapped_addrinfo(
+    int requested_family,
+    struct addrinfo *res)
+{
+#if defined(ENABLE_IPV6) && defined(IN6_IS_ADDR_V4MAPPED)
+    struct sockaddr_in6 *addr6;
+    struct sockaddr_in addr4;
+
+    if (requested_family != AF_UNSPEC ||
+        res == NULL ||
+        res->ai_family != AF_INET6 ||
+        res->ai_addr == NULL ||
+        res->ai_addrlen < sizeof(struct sockaddr_in6)) {
+        return;
+    }
+
+    addr6 = (struct sockaddr_in6 *) res->ai_addr;
+    if (!IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
+        return;
+    }
+
+    memset(&addr4, 0, sizeof(addr4));
+    addr4.sin_family = AF_INET;
+    addr4.sin_port = addr6->sin6_port;
+    memcpy(&addr4.sin_addr,
+           &addr6->sin6_addr.s6_addr[sizeof(addr6->sin6_addr.s6_addr) -
+                                     sizeof(addr4.sin_addr)],
+           sizeof(addr4.sin_addr));
+
+    memcpy(res->ai_addr, &addr4, sizeof(addr4));
+    res->ai_addrlen = sizeof(addr4);
+    res->ai_family = AF_INET;
+#else
+    (void) requested_family;
+    (void) res;
+#endif
+}
+
 /*
     For historical reasons, we need a hostent structure to represent
     our remote target for probing.  The obsolete way of doing this
@@ -865,6 +903,7 @@ int get_addrinfo_from_name(
         return -1;
     }
 
+    unmap_v4mapped_addrinfo(hints.ai_family, *res);
     ctl->af = (*res)->ai_family;
     return 0;
 }
@@ -918,6 +957,7 @@ static int validate_report_targets(
             return -1;
         }
 
+        unmap_v4mapped_addrinfo(hints.ai_family, res);
         lookup_ctl.af = res->ai_family;
         freeaddrinfo(res);
         names = names->next;


### PR DESCRIPTION
## Summary
- convert IPv4-mapped IPv6 lookup results to IPv4 when the user did not force an address family
- keep explicit `-6` behavior unchanged

## Why
With the default `AF_UNSPEC` lookup, a target such as `::ffff:127.0.0.1` can resolve as an IPv6 sockaddr carrying an IPv4-mapped address. Passing that mapped IPv6 sockaddr into the probe path fails with `Address not available` on this system, even though the mapped IPv4 destination itself is reachable.

After this change, default-family lookups unwrap the mapped address and probe it through the IPv4 path. If the user explicitly asks for IPv6 with `-6`, the mapped IPv6 result is left alone.

## Provenance
- Ported from `yvs2014/mtr085@2ad17005e0dabb6934d0a3e93aa80f3b8e7af703`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records the source SHA.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- Before the change, `./mtr --report --report-cycles 1 ::ffff:127.0.0.1` failed with `Address not available`
- After the change, `./mtr --report --report-cycles 1 ::ffff:127.0.0.1` succeeds and reports `localhost`
- `./mtr -6 --report --report-cycles 1 ::ffff:127.0.0.1` still fails with `Address not available`, confirming explicit IPv6 selection is not remapped
