### PR TITLE
curses: support keypad scroll keys

### DIFF
--- a/ui/curses.c
+++ b/ui/curses.c
@@ -199,8 +199,12 @@ int mtr_curses_keyaction(
         return ActionAS;
 #endif
     case '+':
+    case KEY_NPAGE:
+    case KEY_DOWN:
         return ActionScrollDown;
     case '-':
+    case KEY_PPAGE:
+    case KEY_UP:
         return ActionScrollUp;
     case 's':
         mvprintw(2, 0, "Change Packet Size: %d\n", ctl->cpacketsize);
@@ -1011,6 +1015,7 @@ void mtr_curses_open(
     initscr();
     raw();
     noecho();
+    keypad(stdscr, TRUE);
     start_color();
     if (use_default_colors() == OK)
         bg_col = -1;


### PR DESCRIPTION
## Summary
- enable curses keypad decoding
- map arrow and page keys onto the existing curses scroll actions

## Why
Curses mode already supports scrolling with `+` and `-`, but special terminal keys are not decoded unless keypad mode is enabled. This ports the keypad setup and scroll-key usability idea from the mtr085 fork while keeping upstream mtr's existing `ActionScrollDown` / `ActionScrollUp` model.

## Provenance
- Adapted from `yvs2014/mtr085@67724401b8549d5ba597671aadced3b0c4cc53b3`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records the source SHA.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- GitHub `compile-linux` and `lint` passed
- Included in the newest-to-oldest stack validation in #646

## Notes
This is an interactive curses behavior change, so terminal-specific confirmation is still useful during review.
