### PR TITLE
options: show build features with -vv

### DIFF
--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -344,6 +344,65 @@ static void init_fld_options(
     ctl->available_options[i] = 0;
 }
 
+static void print_build_feature(
+    const char *name,
+    int enabled)
+{
+    printf("  %-8s %s\n", name, enabled ? "yes" : "no");
+}
+
+static void print_version(
+    int verbose)
+{
+    printf("mtr " PACKAGE_VERSION "\n");
+
+    if (verbose < 2) {
+        return;
+    }
+
+    puts("features:");
+#ifdef ENABLE_IPV6
+    print_build_feature("ipv6", 1);
+#else
+    print_build_feature("ipv6", 0);
+#endif
+#ifdef HAVE_CURSES
+    print_build_feature("curses", 1);
+#else
+    print_build_feature("curses", 0);
+#endif
+#ifdef HAVE_CURSESW
+    print_build_feature("cursesw", 1);
+#else
+    print_build_feature("cursesw", 0);
+#endif
+#ifdef ENABLE_BRAILLE
+    print_build_feature("braille", 1);
+#else
+    print_build_feature("braille", 0);
+#endif
+#ifdef HAVE_GTK
+    print_build_feature("gtk", 1);
+#else
+    print_build_feature("gtk", 0);
+#endif
+#ifdef HAVE_JANSSON
+    print_build_feature("json", 1);
+#else
+    print_build_feature("json", 0);
+#endif
+#ifdef HAVE_IPINFO
+    print_build_feature("ipinfo", 1);
+#else
+    print_build_feature("ipinfo", 0);
+#endif
+#ifdef SO_MARK
+    print_build_feature("mark", 1);
+#else
+    print_build_feature("mark", 0);
+#endif
+}
+
 
 static void parse_arg(
     struct mtr_ctl *ctl,
@@ -441,6 +500,7 @@ static void parse_arg(
     enum { num_options = sizeof(long_options) / sizeof(struct option) };
     char short_options[num_options * 2];
     size_t n, p;
+    int version_count = 0;
 
     for (n = p = 0; n < num_options; n++) {
         if (CHAR_MAX < long_options[n].val) {
@@ -462,8 +522,7 @@ static void parse_arg(
 
         switch (opt) {
         case 'v':
-            printf("mtr " PACKAGE_VERSION "\n");
-            exit(EXIT_SUCCESS);
+            version_count++;
             break;
         case 'h':
             usage(stdout);
@@ -723,6 +782,11 @@ static void parse_arg(
         default:
             usage(stderr);
         }
+    }
+
+    if (version_count > 0) {
+        print_version(version_count);
+        exit(EXIT_SUCCESS);
     }
 
     if (ctl->DisplayMode == DisplayReport ||


### PR DESCRIPTION
## Summary
- keep `-v` / `--version` output unchanged
- make repeated `-v` (`-vv`) also print the main compiled-in feature switches

## Why
The plain version string is useful for scripts and remains stable. When debugging user reports, though, knowing whether the binary was built with IPv6, curses, JSON, GTK, ipinfo, etc. is often the next question. This adds that information behind the more verbose `-vv` form.

## Provenance
- Adapted from the verbose-version idea in `yvs2014/mtr085@eb6f41cfcc4bc7c741805769efa88cc2de9ac99d`
- Original author: `yvs <VSYakovetsky@gmail.com>`
- The commit keeps that original author and records the source SHA.

## Validation
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- `./mtr -v` still prints only `mtr 0.96`
- `./mtr -vv` prints `mtr 0.96` followed by the feature list
