### PR TITLE
feat(ipinfo): accept multiple fields

### DIFF
--- a/bash-completion/mtr
+++ b/bash-completion/mtr
@@ -54,7 +54,8 @@ _mtr_module()
         --filename --inet --inet6 --udp --tcp --address --first-ttl
         --max-ttl --max-unknown --port --localport --psize --bitpattern
         --interval --gracetime --tos --mpls --timeout --mark --report
-        --report-wide --report-cycles --json --xml --csv --raw --split
+        --report-wide --report-on-exit --report-cycles --json --xml --csv
+        --raw --split
         --curses --displaymode --gtk --no-dns --show-ips --order --ipinfo
         --aslookup --help --version
       '

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -178,6 +178,8 @@ mode.  When in this mode,
 will run for the number of cycles specified by the
 .B \-c
 option, and then print statistics and exit.
+Use report mode when you need a final result that remains in terminal
+scrollback or can be redirected to a file.
 .TP
 \c
 This mode is useful for generating statistics about network quality.
@@ -243,6 +245,13 @@ In stripchart modes,
 marks a probe that has not received a response, and
 .B >
 marks a response slower than the largest latency bucket shown in the scale.
+The scale buckets are chosen from the current minimum and maximum visible
+round-trip times; in the default stripchart,
+.B .
+marks the smallest bucket, digits and lowercase letters mark intermediate
+buckets, and
+.B >
+marks values above the last displayed bucket.
 .TP
 .B \-g\fR, \fB\-\-gtk
 Use this option to force

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -17,6 +17,9 @@ mtr \- a network diagnostic tool
 .B \-\-report-wide\c
 ]
 [\c
+.B \-\-report\-on\-exit\c
+]
+[\c
 .B \-\-xml\c
 ]
 [\c
@@ -201,6 +204,11 @@ into
 mode.  When in this mode,
 .B mtr
 will not cut hostnames in the report.
+.TP
+.B \-\-report\-on\-exit
+Use this option with the curses interface to print a report snapshot after
+leaving curses mode. This keeps the last trace visible in terminals that switch
+to an alternate screen while curses is active.
 .TP
 .B \-x\fR, \fB\-\-xml
 Use this option to tell

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -359,8 +359,10 @@ I%Interarrival Jitter
 Example:
 -o "LSD NBAW  X"
 .TP
-.B \-y \fIn\fR, \fB\-\-ipinfo \fIn
-Displays information about each IP hop.  Valid values for \fIn\fR are:
+.B \-y \fIFIELDS\fR, \fB\-\-ipinfo \fIFIELDS
+Displays information about each IP hop.
+.I FIELDS
+can be one value or a comma-separated list of values.  Valid field values are:
 .TS
 tab(%);
 ll.
@@ -372,7 +374,7 @@ ll.
 .TE
 .br
 
-It is possible to cycle between these fields at runtime (using the \fBy\fR key).
+In curses mode, use the \fBy\fR key to cycle between these fields one at a time.
 IP information lookup is disabled by default unless this option or
 \fB-z\fR is used.
 .TP

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -127,6 +127,31 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.returncode, 0)
         self.assertIn('--report-on-exit', reply.stdout)
 
+    def test_bad_host_fails_in_output_modes(self):
+        'Test failed host resolution exits non-zero in output modes.'
+
+        modes = [
+            '--csv',
+            '--raw',
+            '--report',
+            '--xml',
+        ]
+
+        reply = self.run_mtr('--help')
+        if '--json' in reply.stdout:
+            modes.append('--json')
+
+        for mode in modes:
+            reply = self.run_mtr(
+                mode,
+                '--report-cycles',
+                '1',
+                'nonexistent.invalid',
+            )
+
+            self.assertNotEqual(reply.returncode, 0)
+            self.assertIn('Failed to resolve host', reply.stderr)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -45,6 +45,16 @@ class TestMtrCommandParse(unittest.TestCase):
             universal_newlines=True,
         )
 
+    def run_mtr_detached(self, *args):
+        return subprocess.run(
+            [MTR] + list(args),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            universal_newlines=True,
+        )
+
     def test_first_ttl_cannot_exceed_max_ttl(self):
         'Test that conflicting first/max TTL options fail fast.'
 
@@ -88,6 +98,7 @@ class TestMtrCommandParse(unittest.TestCase):
 
         reply = self.run_mtr(
             '--report',
+
             '--report-cycles',
             '1',
             '--no-dns',
@@ -98,6 +109,19 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.stderr, '')
         self.assertIn('Loss%', reply.stdout)
         self.assertIn('0.00%', reply.stdout)
+
+    def test_split_exits_with_closed_stdin(self):
+        'Test split mode exits when stdin is /dev/null.'
+
+        reply = self.run_mtr_detached(
+            '--split',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
 
     def test_mtr_options_preserves_quoted_order_spaces(self):
         'Test that quoted MTR_OPTIONS values can contain order separators.'

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -98,7 +98,6 @@ class TestMtrCommandParse(unittest.TestCase):
 
         reply = self.run_mtr(
             '--report',
-
             '--report-cycles',
             '1',
             '--no-dns',
@@ -175,6 +174,31 @@ class TestMtrCommandParse(unittest.TestCase):
 
             self.assertNotEqual(reply.returncode, 0)
             self.assertIn('Failed to resolve host', reply.stderr)
+
+    def test_ipinfo_accepts_multiple_fields(self):
+        'Test parsing a comma-separated ipinfo field list.'
+
+        reply = self.run_mtr('--help')
+        if '--ipinfo' not in reply.stdout:
+            self.skipTest('No ipinfo support')
+
+        reply = self.run_mtr('--ipinfo', '0,1', '--help')
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+
+    def test_ipinfo_rejects_bad_field_list(self):
+        'Test malformed comma-separated ipinfo field lists.'
+
+        reply = self.run_mtr('--help')
+        if '--ipinfo' not in reply.stdout:
+            self.skipTest('No ipinfo support')
+
+        for fields in ('0,,1', '0,5', '0,x'):
+            reply = self.run_mtr('--ipinfo', fields, '--help')
+
+            self.assertNotEqual(reply.returncode, 0)
+            self.assertIn('ipinfo', reply.stderr)
 
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -119,6 +119,14 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertIn('Drop', reply.stdout)
         self.assertIn('Jint', reply.stdout)
 
+    def test_help_lists_report_on_exit(self):
+        'Test that the curses exit snapshot option remains advertised.'
+
+        reply = self.run_mtr('--help')
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertIn('--report-on-exit', reply.stdout)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -35,11 +35,13 @@ MTR = os.path.join(PROJECT_ROOT, 'mtr')
 class TestMtrCommandParse(unittest.TestCase):
     '''Test cases with malformed mtr command-line arguments.'''
 
-    def run_mtr(self, *args):
+    def run_mtr(self, *args, **kwargs):
+        env = kwargs.get('env')
         return subprocess.run(
             [MTR] + list(args),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
             universal_newlines=True,
         )
 
@@ -96,6 +98,26 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.stderr, '')
         self.assertIn('Loss%', reply.stdout)
         self.assertIn('0.00%', reply.stdout)
+
+    def test_mtr_options_preserves_quoted_order_spaces(self):
+        'Test that quoted MTR_OPTIONS values can contain order separators.'
+
+        env = os.environ.copy()
+        env['MTR_OPTIONS'] = '--order "SRDL NBAGVW JMXI"'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+            env=env,
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+        self.assertIn('Drop', reply.stdout)
+        self.assertIn('Jint', reply.stdout)
 
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -81,6 +81,22 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertIn('port number specified (-P)', reply.stderr)
         self.assertIn('protocol is ICMP', reply.stderr)
 
+    def test_report_loss_uses_two_decimal_places(self):
+        'Test report mode preserves fine-grained loss percentage precision.'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+        self.assertIn('Loss%', reply.stdout)
+        self.assertIn('0.00%', reply.stdout)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -67,7 +67,8 @@
 #define UNKN	"???"
 
 static int iihash = 0;
-static char fmtinfo[32];
+static char fmtinfo[128];
+static char fmtfield[128];
 
 /* items width: ASN, Route, Country, Registry, Allocated */
 static const int iiwidth[] = { 12, 19, 4, 8, 11 };       /* item len + space */
@@ -263,7 +264,8 @@ static char *ipinfo_lookup(
 /* originX.asn.cymru.com txtrec:    ASN | Route | Country | Registry | Allocated */
 static char *split_txtrec(
     struct mtr_ctl *ctl,
-    char *txt_rec)
+    char *txt_rec,
+    int ipinfo_no)
 {
     char *prev;
     char *next;
@@ -298,10 +300,10 @@ static char *split_txtrec(
 
     if (i > ctl->ipinfo_max)
         ctl->ipinfo_max = i;
-    if (ctl->ipinfo_no >= i) {
+    if (ipinfo_no >= i) {
         return (*items)[0];
     } else
-        return (*items)[ctl->ipinfo_no];
+        return (*items)[ipinfo_no];
 }
 
 #ifdef ENABLE_IPV6
@@ -328,9 +330,69 @@ static bool is_well_known_nat64(struct in6_addr *addr){
 }
 #endif
 
+void set_ipinfo_field(
+    struct mtr_ctl *ctl,
+    int ipinfo_no)
+{
+    ctl->ipinfo_no = ipinfo_no;
+    ctl->ipinfo_fields[0] = ipinfo_no;
+    ctl->ipinfo_field_count = 1;
+}
+
+void parse_ipinfo_fields(
+    struct mtr_ctl *ctl,
+    const char *fields)
+{
+    char *fields_copy;
+    char *field;
+    char *next;
+
+    fields_copy = xstrdup(fields);
+    ctl->ipinfo_field_count = 0;
+
+    for (field = fields_copy; field != NULL; field = next) {
+        char *end;
+        int ipinfo_no;
+
+        next = strchr(field, ',');
+        if (next != NULL) {
+            *next = '\0';
+            next++;
+        }
+
+        if (*field == '\0') {
+            error(EXIT_FAILURE, 0, "empty ipinfo field in '%s'", fields);
+        }
+
+        errno = 0;
+        ipinfo_no = strtol(field, &end, 0);
+        if (errno != 0 || field == end || *end != '\0') {
+            error(EXIT_FAILURE, errno, "invalid ipinfo field '%s' in '%s'",
+                  field, fields);
+        }
+        if (ipinfo_no < 0 || 4 < ipinfo_no) {
+            error(EXIT_FAILURE, 0, "ipinfo value %d out of range (0 - 4)",
+                  ipinfo_no);
+        }
+        if (ctl->ipinfo_field_count == MAX_IPINFO_FIELDS) {
+            error(EXIT_FAILURE, 0, "too many ipinfo fields in '%s'", fields);
+        }
+
+        ctl->ipinfo_fields[ctl->ipinfo_field_count++] = ipinfo_no;
+    }
+
+    if (ctl->ipinfo_field_count == 0) {
+        error(EXIT_FAILURE, 0, "empty ipinfo field in '%s'", fields);
+    }
+
+    ctl->ipinfo_no = ctl->ipinfo_fields[0];
+    free(fields_copy);
+}
+
 static char *get_ipinfo(
     struct mtr_ctl *ctl,
-    ip_t * addr)
+    ip_t * addr,
+    int ipinfo_no)
 {
     char key[NAMELEN];
     char lookup_key[NAMELEN];
@@ -381,7 +443,7 @@ static char *get_ipinfo(
         item.key = key;
         item.data = NULL;
         if ((found_item = hsearch(item, FIND))) {
-            if (!(val = (*((items_t *) found_item->data))[ctl->ipinfo_no]))
+            if (!(val = (*((items_t *) found_item->data))[ipinfo_no]))
                 val = (*((items_t *) found_item->data))[0];
             DEB_syslog(LOG_INFO, "Found (hashed): %s", val);
         }
@@ -389,7 +451,7 @@ static char *get_ipinfo(
 
     if (!val) {
         DEB_syslog(LOG_INFO, "Lookup: %s", key);
-        if ((val = split_txtrec(ctl, ipinfo_lookup(lookup_key)))) {
+        if ((val = split_txtrec(ctl, ipinfo_lookup(lookup_key), ipinfo_no))) {
             DEB_syslog(LOG_INFO, "Looked up: %s", key);
             if (iihash)
                 if ((item.key = xstrdup(key))) {
@@ -419,22 +481,86 @@ ATTRIBUTE_CONST int get_iiwidth(
     return iiwidth[ipinfo_no % len];
 }
 
+int get_iiwidth_selected(
+    struct mtr_ctl *ctl)
+{
+    int width = 0;
+    int i;
+
+    for (i = 0; i < ctl->ipinfo_field_count; i++) {
+        if (i)
+            width++;
+        width += get_iiwidth(ctl->ipinfo_fields[i]);
+        if (ctl->ipinfo_fields[i] == 0)
+            width += 2;        /* align header: AS */
+    }
+
+    return width;
+}
+
+int ipinfo_field_selected(
+    struct mtr_ctl *ctl,
+    int ipinfo_no)
+{
+    int i;
+
+    for (i = 0; i < ctl->ipinfo_field_count; i++) {
+        if (ctl->ipinfo_fields[i] == ipinfo_no)
+            return 1;
+    }
+
+    return 0;
+}
+
+char *fmt_ipinfo_field(
+    struct mtr_ctl *ctl,
+    ip_t * addr,
+    int ipinfo_no)
+{
+    char *ipinfo = get_ipinfo(ctl, addr, ipinfo_no);
+    char fmt[8];
+
+    snprintf(fmt, sizeof(fmt), "%s%%-%ds", ipinfo_no ? "" : "AS",
+             get_iiwidth(ipinfo_no));
+    snprintf(fmtfield, sizeof(fmtfield), fmt, ipinfo ? ipinfo : UNKN);
+
+    return fmtfield;
+}
+
 char *fmt_ipinfo(
     struct mtr_ctl *ctl,
     ip_t * addr)
 {
-    char *ipinfo = get_ipinfo(ctl, addr);
-    char fmt[8];
-    snprintf(fmt, sizeof(fmt), "%s%%-%ds", ctl->ipinfo_no ? "" : "AS",
-             get_iiwidth(ctl->ipinfo_no));
-    snprintf(fmtinfo, sizeof(fmtinfo), fmt, ipinfo ? ipinfo : UNKN);
+    size_t offset = 0;
+    int i;
+
+    fmtinfo[0] = '\0';
+    for (i = 0; i < ctl->ipinfo_field_count; i++) {
+        int ipinfo_no = ctl->ipinfo_fields[i];
+        char *ipinfo = fmt_ipinfo_field(ctl, addr, ipinfo_no);
+        int written;
+
+        if (i && offset < sizeof(fmtinfo) - 1) {
+            fmtinfo[offset++] = ' ';
+            fmtinfo[offset] = '\0';
+        }
+
+        written = snprintf(fmtinfo + offset, sizeof(fmtinfo) - offset, "%s",
+                           ipinfo);
+        if (written < 0 || (size_t) written >= sizeof(fmtinfo) - offset) {
+            fmtinfo[sizeof(fmtinfo) - 1] = '\0';
+            break;
+        }
+        offset += written;
+    }
+
     return fmtinfo;
 }
 
 int is_printii(
     struct mtr_ctl *ctl)
 {
-    return (ctl->ipinfo_no >= 0);
+    return (ctl->ipinfo_field_count > 0);
 }
 
 void asn_open(

--- a/ui/asn.h
+++ b/ui/asn.h
@@ -25,9 +25,24 @@ extern void asn_close(
 extern char *fmt_ipinfo(
     struct mtr_ctl *ctl,
     ip_t * addr);
+extern char *fmt_ipinfo_field(
+    struct mtr_ctl *ctl,
+    ip_t * addr,
+    int ipinfo_no);
+extern int ipinfo_field_selected(
+    struct mtr_ctl *ctl,
+    int ipinfo_no);
 extern ATTRIBUTE_CONST size_t get_iiwidth_len(
     void);
 extern ATTRIBUTE_CONST int get_iiwidth(
     int ipinfo_no);
+extern int get_iiwidth_selected(
+    struct mtr_ctl *ctl);
 extern int is_printii(
     struct mtr_ctl *ctl);
+extern void set_ipinfo_field(
+    struct mtr_ctl *ctl,
+    int ipinfo_no);
+extern void parse_ipinfo_fields(
+    struct mtr_ctl *ctl,
+    const char *fields);

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -949,7 +949,7 @@ void mtr_curses_redraw(
 
 #ifdef HAVE_IPINFO
         if (is_printii(ctl))
-            padding += get_iiwidth(ctl->ipinfo_no);
+            padding += get_iiwidth_selected(ctl);
 #endif
         max_cols =
             maxx <= SAVED_PINGS + padding ? maxx - padding : SAVED_PINGS;

--- a/ui/display.c
+++ b/ui/display.c
@@ -146,6 +146,8 @@ void display_close(
         asn_close(ctl);
 #endif
         mtr_curses_close();
+        if (ctl->ReportOnExit)
+            report_close(ctl);
         break;
 #endif
     case DisplaySplit:

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -373,7 +373,7 @@ static void percent_formatter(
     gfloat f;
     gchar text[64];
     gtk_tree_model_get(tree_model, iter, POINTER_TO_INT(data), &f, -1);
-    snprintf(text, sizeof(text), "%.1f%%", f);
+    snprintf(text, sizeof(text), "%.2f%%", f);
     g_object_set(cell, "text", text, NULL);
 }
 

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -69,7 +69,7 @@ char *myname;
 const struct fields data_fields[MAXFLD] = {
     /* key, Remark, Header, Format, Width, CallBackFunc */
     {' ', "<sp>: Space between fields", " ", " ", 1, &net_drop},
-    {'L', "L: Loss Ratio", "Loss%", " %4.1f%%", 6, &net_loss},
+    {'L', "L: Loss Ratio", "Loss%", " %6.2f%%", 8, &net_loss},
     {'D', "D: Dropped Packets", "Drop", " %4d", 5, &net_drop},
     {'R', "R: Received Packets", "Rcv", " %5d", 6, &net_returned},
     {'S', "S: Sent Packets", "Snt", " %5d", 6, &net_xmit},

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -147,7 +147,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs(" -b, --show-ips                   show IP numbers and host names\n", out);
     fputs(" -o, --order FIELDS               select output fields\n", out);
 #ifdef HAVE_IPINFO
-    fputs(" -y, --ipinfo NUMBER              select IP information in output\n",
+    fputs(" -y, --ipinfo FIELDS              select IP information fields in output\n",
           out);
     fputs(" -z, --aslookup                   display AS number\n", out);
     fputs("     --ipinfo_provider4           provider for IPv4 AS lookups\n", out);
@@ -759,15 +759,10 @@ static void parse_arg(
 #endif
 #ifdef HAVE_IPINFO
         case 'y':
-            ctl->ipinfo_no =
-                strtoint_or_err(optarg, "invalid argument");
-            if (ctl->ipinfo_no < 0 || 4 < ctl->ipinfo_no) {
-                error(EXIT_FAILURE, 0, "value %d out of range (0 - 4)",
-                      ctl->ipinfo_no);
-            }
+            parse_ipinfo_fields(ctl, optarg);
             break;
         case 'z':
-            ctl->ipinfo_no = 0;
+            set_ipinfo_field(ctl, 0);
             break;
         case OPT_IPINFO4:
             ctl->ipinfo_provider4 = optarg;
@@ -1066,6 +1061,7 @@ int main(
     ctl.maxDisplayPath = 8;
     ctl.probe_timeout = 10 * 1000000;
     ctl.ipinfo_no = -1;
+    ctl.ipinfo_field_count = 0;
     ctl.ipinfo_max = -1;
 #ifdef HAVE_IPINFO
     ctl.ipinfo_provider4 = "origin.asn.cymru.com";

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -127,6 +127,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 #endif
     fputs(" -r, --report                     output using report mode\n", out);
     fputs(" -w, --report-wide                output wide report\n", out);
+    fputs("     --report-on-exit             print report after curses exits\n", out);
     fputs(" -c, --report-cycles COUNT        set the number of pings sent\n", out);
 #ifdef HAVE_JANSSON
     fputs(" -j, --json                       output json\n", out);
@@ -420,12 +421,13 @@ static void parse_arg(
      */
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
-        OPT_IPINFO4 = CHAR_MAX + 2,
+        OPT_REPORT_ON_EXIT = CHAR_MAX + 2,
+        OPT_IPINFO4 = CHAR_MAX + 3,
 #ifdef ENABLE_IPV6
-        OPT_IPINFO6 = CHAR_MAX + 3,
-        OPT_CACHE = CHAR_MAX + 4,
+        OPT_IPINFO6 = CHAR_MAX + 4,
+        OPT_CACHE = CHAR_MAX + 5,
 #else
-        OPT_CACHE = CHAR_MAX + 3,
+        OPT_CACHE = CHAR_MAX + 4,
 #endif /* ifdef ENABLE_IPV6 */
     };
     static const struct option long_options[] = {
@@ -441,6 +443,7 @@ static void parse_arg(
 
         {"report", 0, NULL, 'r'},
         {"report-wide", 0, NULL, 'w'},
+        {"report-on-exit", 0, NULL, OPT_REPORT_ON_EXIT},
         {"xml", 0, NULL, 'x'},
 #ifdef HAVE_CURSES
         {"curses", 0, NULL, 't'},
@@ -534,6 +537,9 @@ static void parse_arg(
         case 'w':
             ctl->reportwide = 1;
             ctl->DisplayMode = DisplayReport;
+            break;
+        case OPT_REPORT_ON_EXIT:
+            ctl->ReportOnExit = 1;
             break;
 #ifdef HAVE_CURSES
         case 't':

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -73,6 +73,7 @@ typedef int time_t;
 #define MAXPACKET 65535          /* largest test packet size */
 #define MINPACKET 28            /* 20 bytes IP header and 8 bytes ICMP or UDP */
 #define MAXLABELS 8             /* http://kb.juniper.net/KB2190 (+ 3 just in case) */
+#define MAX_IPINFO_FIELDS 5
 
 /* Stream Control Transmission Protocol is defined in netinet/in.h */
 #ifdef IPPROTO_SCTP
@@ -92,6 +93,8 @@ struct mtr_ctl {
     char *InterfaceAddress;
     char LocalHostname[128];
     int ipinfo_no;
+    int ipinfo_fields[MAX_IPINFO_FIELDS];
+    int ipinfo_field_count;
     int ipinfo_max;
     int cpacketsize;            /* packet size used by ping */
     int bitpattern;             /* packet bit pattern used by ping */

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -122,7 +122,8 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1, cache:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
+        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5,
+        CompactLayout:1, ReportOnExit:1;
 #ifdef HAVE_IPINFO
 #ifdef ENABLE_IPV6
     char *ipinfo_provider6;

--- a/ui/report.c
+++ b/ui/report.c
@@ -171,6 +171,7 @@ void report_close(
     char fmt[16];
     size_t len = 0;
     size_t len_hosts = 33;
+    size_t stat_start = len_hosts;
 #ifdef HAVE_IPINFO
     int len_tmp;
     const size_t iiwidth_len = get_iiwidth_len();
@@ -191,13 +192,11 @@ void report_close(
     }
 #ifdef HAVE_IPINFO
     len_tmp = len_hosts;
-    if (ctl->ipinfo_no >= 0 && iiwidth_len) {
-        ctl->ipinfo_no %= iiwidth_len;
+    if (is_printii(ctl) && iiwidth_len) {
+        len_tmp += get_iiwidth_selected(ctl);
+        stat_start = len_tmp;
         if (ctl->reportwide) {
             len_hosts++;        /* space */
-            len_tmp += get_iiwidth(ctl->ipinfo_no);
-            if (!ctl->ipinfo_no)
-                len_tmp += 2;   /* align header: AS */
         }
     }
     snprintf(fmt, sizeof(fmt), "HOST: %%-%ds", len_tmp);
@@ -205,7 +204,7 @@ void report_close(
     snprintf(fmt, sizeof(fmt), "HOST: %%-%zus", len_hosts);
 #endif
     snprintf(buf, sizeof(buf), fmt, ctl->LocalHostname);
-    len = ctl->reportwide ? strlen(buf) : len_hosts;
+    len = ctl->reportwide ? strlen(buf) : stat_start;
     for (i = 0; i < MAXFLD; i++) {
         j = ctl->fld_index[ctl->fld_active[i]];
         if (j < 0)
@@ -236,7 +235,7 @@ void report_close(
 #ifdef HAVE_IPINFO
         }
 #endif
-        len = ctl->reportwide ? strlen(buf) : len_hosts;
+        len = ctl->reportwide ? strlen(buf) : stat_start;
         for (i = 0; i < MAXFLD; i++) {
             j = ctl->fld_index[ctl->fld_active[i]];
             if (j < 0)
@@ -420,8 +419,8 @@ void json_close(struct mtr_ctl *ctl)
             goto on_error;
 
 #ifdef HAVE_IPINFO
-        if (!ctl->ipinfo_no) {
-            char* fmtinfo = fmt_ipinfo(ctl, addr);
+        if (ipinfo_field_selected(ctl, 0)) {
+            char* fmtinfo = fmt_ipinfo_field(ctl, addr, 0);
             if (fmtinfo != NULL)
                 fmtinfo = trim(fmtinfo, '\0');
 
@@ -573,7 +572,7 @@ void csv_close(
         if (at == net_min(ctl)) {
             printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip,");
 #ifdef HAVE_IPINFO
-            if (!ctl->ipinfo_no) {
+            if (ipinfo_field_selected(ctl, 0)) {
                 printf("Asn,");
             }
 #endif
@@ -590,8 +589,8 @@ void csv_close(
             printf("\n");
         }
 #ifdef HAVE_IPINFO
-        if (!ctl->ipinfo_no) {
-            char *fmtinfo = fmt_ipinfo(ctl, addr);
+        if (ipinfo_field_selected(ctl, 0)) {
+            char *fmtinfo = fmt_ipinfo_field(ctl, addr, 0);
             fmtinfo = trim(fmtinfo, '\0');
             printf("MTR.%s,%lld,%s,%s,%d,%s,%s", PACKAGE_VERSION,
                    (long long) now, "OK", ctl->Hostname, at + 1, name,
@@ -646,8 +645,8 @@ void csv_close(
 
                 if (!found) {
 #ifdef HAVE_IPINFO
-                    if (!ctl->ipinfo_no) {
-                        char *fmtinfo = fmt_ipinfo(ctl, addr2);
+                    if (ipinfo_field_selected(ctl, 0)) {
+                        char *fmtinfo = fmt_ipinfo_field(ctl, addr2, 0);
                         fmtinfo = trim(fmtinfo, '\0');
                         printf("MTR.%s,%lld,%s,%s,%d,%s,%s", PACKAGE_VERSION,
                             (long long) now, "OK", ctl->Hostname, at + 1, name,

--- a/ui/select.c
+++ b/ui/select.c
@@ -342,9 +342,16 @@ void select_loop(
                 ctl->ipinfo_no++;
                 if (ctl->ipinfo_no > ctl->ipinfo_max)
                     ctl->ipinfo_no = 0;
+                set_ipinfo_field(ctl, ctl->ipinfo_no);
                 break;
             case ActionAS:
-                ctl->ipinfo_no = ctl->ipinfo_no ? 0 : ctl->ipinfo_max;
+                if (ctl->ipinfo_no == 0 && ctl->ipinfo_max >= 0)
+                    set_ipinfo_field(ctl, ctl->ipinfo_max);
+                else if (ctl->ipinfo_no == 0) {
+                    ctl->ipinfo_no = -1;
+                    ctl->ipinfo_field_count = 0;
+                } else
+                    set_ipinfo_field(ctl, 0);
                 break;
 #endif
 


### PR DESCRIPTION
## Summary
- accept comma-separated `--ipinfo` field lists such as `--ipinfo 0,1`
- print the selected fields together in curses/report-wide host prefixes
- keep interactive `y`/`z` cycling compatible by collapsing back to a single selected field
- add command-line parser coverage for valid and malformed field lists, including non-numeric entries
- report malformed entries as `ipinfo` parser errors instead of a generic invalid argument

Fixes #201.

Inspired by the multiple-ipinfo behavior shown by yvs2014 in https://github.com/yvs2014/mtr085. This is a fresh implementation for the current upstream `ui/asn.c` code path rather than a cherry-pick from that fork.

## Tests
- `git diff --check`
- `make -j$(nproc)`
- `sudo python3 ./test/cmdparse.py`
- `./mtr --ipinfo 0,1 --help`
- `./mtr --ipinfo 0,,1 --help` exits non-zero with an ipinfo parser error
- `./mtr --ipinfo 0,x --help` exits non-zero with an ipinfo parser error
