### PR TITLE
docs(man): explain stripchart scale symbols

### DIFF
--- a/bash-completion/mtr
+++ b/bash-completion/mtr
@@ -54,7 +54,8 @@ _mtr_module()
         --filename --inet --inet6 --udp --tcp --address --first-ttl
         --max-ttl --max-unknown --port --localport --psize --bitpattern
         --interval --gracetime --tos --mpls --timeout --mark --report
-        --report-wide --report-cycles --json --xml --csv --raw --split
+        --report-wide --report-on-exit --report-cycles --json --xml --csv
+        --raw --split
         --curses --displaymode --gtk --no-dns --show-ips --order --ipinfo
         --aslookup --help --version
       '

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -178,6 +178,8 @@ mode.  When in this mode,
 will run for the number of cycles specified by the
 .B \-c
 option, and then print statistics and exit.
+Use report mode when you need a final result that remains in terminal
+scrollback or can be redirected to a file.
 .TP
 \c
 This mode is useful for generating statistics about network quality.
@@ -243,6 +245,13 @@ In stripchart modes,
 marks a probe that has not received a response, and
 .B >
 marks a response slower than the largest latency bucket shown in the scale.
+The scale buckets are chosen from the current minimum and maximum visible
+round-trip times; in the default stripchart,
+.B .
+marks the smallest bucket, digits and lowercase letters mark intermediate
+buckets, and
+.B >
+marks values above the last displayed bucket.
 .TP
 .B \-g\fR, \fB\-\-gtk
 Use this option to force

--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -17,6 +17,9 @@ mtr \- a network diagnostic tool
 .B \-\-report-wide\c
 ]
 [\c
+.B \-\-report\-on\-exit\c
+]
+[\c
 .B \-\-xml\c
 ]
 [\c
@@ -201,6 +204,11 @@ into
 mode.  When in this mode,
 .B mtr
 will not cut hostnames in the report.
+.TP
+.B \-\-report\-on\-exit
+Use this option with the curses interface to print a report snapshot after
+leaving curses mode. This keeps the last trace visible in terminals that switch
+to an alternate screen while curses is active.
 .TP
 .B \-x\fR, \fB\-\-xml
 Use this option to tell

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -127,6 +127,31 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.returncode, 0)
         self.assertIn('--report-on-exit', reply.stdout)
 
+    def test_bad_host_fails_in_output_modes(self):
+        'Test failed host resolution exits non-zero in output modes.'
+
+        modes = [
+            '--csv',
+            '--raw',
+            '--report',
+            '--xml',
+        ]
+
+        reply = self.run_mtr('--help')
+        if '--json' in reply.stdout:
+            modes.append('--json')
+
+        for mode in modes:
+            reply = self.run_mtr(
+                mode,
+                '--report-cycles',
+                '1',
+                'nonexistent.invalid',
+            )
+
+            self.assertNotEqual(reply.returncode, 0)
+            self.assertIn('Failed to resolve host', reply.stderr)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -45,6 +45,16 @@ class TestMtrCommandParse(unittest.TestCase):
             universal_newlines=True,
         )
 
+    def run_mtr_detached(self, *args):
+        return subprocess.run(
+            [MTR] + list(args),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            universal_newlines=True,
+        )
+
     def test_first_ttl_cannot_exceed_max_ttl(self):
         'Test that conflicting first/max TTL options fail fast.'
 
@@ -88,6 +98,7 @@ class TestMtrCommandParse(unittest.TestCase):
 
         reply = self.run_mtr(
             '--report',
+
             '--report-cycles',
             '1',
             '--no-dns',
@@ -98,6 +109,19 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.stderr, '')
         self.assertIn('Loss%', reply.stdout)
         self.assertIn('0.00%', reply.stdout)
+
+    def test_split_exits_with_closed_stdin(self):
+        'Test split mode exits when stdin is /dev/null.'
+
+        reply = self.run_mtr_detached(
+            '--split',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
 
     def test_mtr_options_preserves_quoted_order_spaces(self):
         'Test that quoted MTR_OPTIONS values can contain order separators.'

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -119,6 +119,14 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertIn('Drop', reply.stdout)
         self.assertIn('Jint', reply.stdout)
 
+    def test_help_lists_report_on_exit(self):
+        'Test that the curses exit snapshot option remains advertised.'
+
+        reply = self.run_mtr('--help')
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertIn('--report-on-exit', reply.stdout)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -35,11 +35,13 @@ MTR = os.path.join(PROJECT_ROOT, 'mtr')
 class TestMtrCommandParse(unittest.TestCase):
     '''Test cases with malformed mtr command-line arguments.'''
 
-    def run_mtr(self, *args):
+    def run_mtr(self, *args, **kwargs):
+        env = kwargs.get('env')
         return subprocess.run(
             [MTR] + list(args),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
             universal_newlines=True,
         )
 
@@ -96,6 +98,26 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertEqual(reply.stderr, '')
         self.assertIn('Loss%', reply.stdout)
         self.assertIn('0.00%', reply.stdout)
+
+    def test_mtr_options_preserves_quoted_order_spaces(self):
+        'Test that quoted MTR_OPTIONS values can contain order separators.'
+
+        env = os.environ.copy()
+        env['MTR_OPTIONS'] = '--order "SRDL NBAGVW JMXI"'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+            env=env,
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+        self.assertIn('Drop', reply.stdout)
+        self.assertIn('Jint', reply.stdout)
 
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'

--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -81,6 +81,22 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertIn('port number specified (-P)', reply.stderr)
         self.assertIn('protocol is ICMP', reply.stderr)
 
+    def test_report_loss_uses_two_decimal_places(self):
+        'Test report mode preserves fine-grained loss percentage precision.'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+        self.assertIn('Loss%', reply.stdout)
+        self.assertIn('0.00%', reply.stdout)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/ui/display.c
+++ b/ui/display.c
@@ -146,6 +146,8 @@ void display_close(
         asn_close(ctl);
 #endif
         mtr_curses_close();
+        if (ctl->ReportOnExit)
+            report_close(ctl);
         break;
 #endif
     case DisplaySplit:

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -373,7 +373,7 @@ static void percent_formatter(
     gfloat f;
     gchar text[64];
     gtk_tree_model_get(tree_model, iter, POINTER_TO_INT(data), &f, -1);
-    snprintf(text, sizeof(text), "%.1f%%", f);
+    snprintf(text, sizeof(text), "%.2f%%", f);
     g_object_set(cell, "text", text, NULL);
 }
 

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -69,7 +69,7 @@ char *myname;
 const struct fields data_fields[MAXFLD] = {
     /* key, Remark, Header, Format, Width, CallBackFunc */
     {' ', "<sp>: Space between fields", " ", " ", 1, &net_drop},
-    {'L', "L: Loss Ratio", "Loss%", " %4.1f%%", 6, &net_loss},
+    {'L', "L: Loss Ratio", "Loss%", " %6.2f%%", 8, &net_loss},
     {'D', "D: Dropped Packets", "Drop", " %4d", 5, &net_drop},
     {'R', "R: Received Packets", "Rcv", " %5d", 6, &net_returned},
     {'S', "S: Sent Packets", "Snt", " %5d", 6, &net_xmit},

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -127,6 +127,7 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
 #endif
     fputs(" -r, --report                     output using report mode\n", out);
     fputs(" -w, --report-wide                output wide report\n", out);
+    fputs("     --report-on-exit             print report after curses exits\n", out);
     fputs(" -c, --report-cycles COUNT        set the number of pings sent\n", out);
 #ifdef HAVE_JANSSON
     fputs(" -j, --json                       output json\n", out);
@@ -420,12 +421,13 @@ static void parse_arg(
      */
     enum {
         OPT_DISPLAYMODE = CHAR_MAX + 1,
-        OPT_IPINFO4 = CHAR_MAX + 2,
+        OPT_REPORT_ON_EXIT = CHAR_MAX + 2,
+        OPT_IPINFO4 = CHAR_MAX + 3,
 #ifdef ENABLE_IPV6
-        OPT_IPINFO6 = CHAR_MAX + 3,
-        OPT_CACHE = CHAR_MAX + 4,
+        OPT_IPINFO6 = CHAR_MAX + 4,
+        OPT_CACHE = CHAR_MAX + 5,
 #else
-        OPT_CACHE = CHAR_MAX + 3,
+        OPT_CACHE = CHAR_MAX + 4,
 #endif /* ifdef ENABLE_IPV6 */
     };
     static const struct option long_options[] = {
@@ -441,6 +443,7 @@ static void parse_arg(
 
         {"report", 0, NULL, 'r'},
         {"report-wide", 0, NULL, 'w'},
+        {"report-on-exit", 0, NULL, OPT_REPORT_ON_EXIT},
         {"xml", 0, NULL, 'x'},
 #ifdef HAVE_CURSES
         {"curses", 0, NULL, 't'},
@@ -534,6 +537,9 @@ static void parse_arg(
         case 'w':
             ctl->reportwide = 1;
             ctl->DisplayMode = DisplayReport;
+            break;
+        case OPT_REPORT_ON_EXIT:
+            ctl->ReportOnExit = 1;
             break;
 #ifdef HAVE_CURSES
         case 't':

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -122,7 +122,8 @@ struct mtr_ctl {
      ForceMaxPing:1,
         use_dns:1, cache:1,
         show_ips:1,
-        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5, CompactLayout:1;
+        enablempls:1, dns:1, reportwide:1, Interactive:1, DisplayMode:5,
+        CompactLayout:1, ReportOnExit:1;
 #ifdef HAVE_IPINFO
 #ifdef ENABLE_IPV6
     char *ipinfo_provider6;


### PR DESCRIPTION
## Summary
- document that report mode is the way to keep final results in scrollback or redirect them to a file
- expand the stripchart display mode description for `?`, `.`, intermediate buckets, and `>`

Fixes #212.

The scale wording follows the explanation yvs2014 gave in the issue thread, adapted for the current man page.

## Tests
- `git diff --check`
