### PR TITLE
feat(output): show loss with two decimals

### DIFF
--- a/test/cmdparse.py
+++ b/test/cmdparse.py
@@ -81,6 +81,22 @@ class TestMtrCommandParse(unittest.TestCase):
         self.assertIn('port number specified (-P)', reply.stderr)
         self.assertIn('protocol is ICMP', reply.stderr)
 
+    def test_report_loss_uses_two_decimal_places(self):
+        'Test report mode preserves fine-grained loss percentage precision.'
+
+        reply = self.run_mtr(
+            '--report',
+            '--report-cycles',
+            '1',
+            '--no-dns',
+            '127.0.0.1',
+        )
+
+        self.assertEqual(reply.returncode, 0)
+        self.assertEqual(reply.stderr, '')
+        self.assertIn('Loss%', reply.stdout)
+        self.assertIn('0.00%', reply.stdout)
+
     def test_port_with_tcp_succeeds_flag(self):
         'Test that specifying -P with -T (TCP) succeeds.'
 

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -373,7 +373,7 @@ static void percent_formatter(
     gfloat f;
     gchar text[64];
     gtk_tree_model_get(tree_model, iter, POINTER_TO_INT(data), &f, -1);
-    snprintf(text, sizeof(text), "%.1f%%", f);
+    snprintf(text, sizeof(text), "%.2f%%", f);
     g_object_set(cell, "text", text, NULL);
 }
 

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -69,7 +69,7 @@ char *myname;
 const struct fields data_fields[MAXFLD] = {
     /* key, Remark, Header, Format, Width, CallBackFunc */
     {' ', "<sp>: Space between fields", " ", " ", 1, &net_drop},
-    {'L', "L: Loss Ratio", "Loss%", " %4.1f%%", 6, &net_loss},
+    {'L', "L: Loss Ratio", "Loss%", " %6.2f%%", 8, &net_loss},
     {'D', "D: Dropped Packets", "Drop", " %4d", 5, &net_drop},
     {'R', "R: Received Packets", "Rcv", " %5d", 6, &net_returned},
     {'S', "S: Sent Packets", "Snt", " %5d", 6, &net_xmit},


### PR DESCRIPTION
## Summary
- show `Loss%` with two decimal places in shared output field formatting
- align the GTK percentage formatter with the same precision
- add report-mode coverage that checks `0.00%` is printed for a no-loss localhost run

Fixes #350.

## Tests
- `git diff --check`
- `./bootstrap.sh && ./configure --without-gtk --without-jansson && make -j "$(nproc)"`
- `sudo python3 ./test/cmdparse.py`
- `sudo ./mtr --report --report-cycles 1 --no-dns 127.0.0.1 | sed -n '1,3p'`
